### PR TITLE
Move Create Queue Button + Title Update + Fix Switches

### DIFF
--- a/packages/app/components/Organization/SettingsTab.tsx
+++ b/packages/app/components/Organization/SettingsTab.tsx
@@ -338,6 +338,7 @@ export default function SettingsTab({
                 tooltip="Whether users use organization's authentication system"
               >
                 <Switch
+                  style={{ backgroundColor: '#1677ff' }}
                   disabled={true}
                   defaultChecked={organization.ssoEnabled}
                 />

--- a/packages/app/components/Queue/TA/EditQueueModal.tsx
+++ b/packages/app/components/Queue/TA/EditQueueModal.tsx
@@ -1,119 +1,122 @@
-import { ReactElement } from "react";
-import Modal from "antd/lib/modal/Modal";
-import { Switch, Input, Form, Button, Radio, message } from "antd";
-import styled from "styled-components";
-import { API } from "@koh/api-client";
-import { useQueue } from "../../../hooks/useQueue";
-import { UpdateQueueParams } from "@koh/common";
-import { pick } from "lodash";
-import { default as React, useEffect, useCallback, useState } from "react";
-import { useRouter } from "next/router";
-import { useCourse } from "../../../hooks/useCourse";
+import { ReactElement } from 'react'
+import Modal from 'antd/lib/modal/Modal'
+import { Switch, Input, Form, Button, Radio, message } from 'antd'
+import styled from 'styled-components'
+import { API } from '@koh/api-client'
+import { useQueue } from '../../../hooks/useQueue'
+import { UpdateQueueParams } from '@koh/common'
+import { pick } from 'lodash'
+import { default as React, useEffect, useCallback, useState } from 'react'
+import { useRouter } from 'next/router'
+import { useCourse } from '../../../hooks/useCourse'
 const NotesInput = styled(Input.TextArea)`
   border-radius: 6px;
   border: 1px solid #b8c4ce;
-`;
+`
 
 interface EditQueueModalProps {
-  queueId: number;
-  visible: boolean;
-  onClose: () => void;
+  queueId: number
+  visible: boolean
+  onClose: () => void
 }
 
 export function EditQueueModal({
   queueId,
   visible,
-  onClose
+  onClose,
 }: EditQueueModalProps): ReactElement {
-  const { queue, mutateQueue } = useQueue(queueId);
-  const [form] = Form.useForm();
-  const [questionsTypeState, setQuestionsTypeState] = useState<string[]>([]);
-  const [questionTypeAddState, setQuestionTypeAddState] = useState("");
-  const router = useRouter();
-  const courseId = router.query["cid"];
-  const course = useCourse(Number(courseId));
+  const { queue, mutateQueue } = useQueue(queueId)
+  const [form] = Form.useForm()
+  const [questionsTypeState, setQuestionsTypeState] = useState<string[]>([])
+  const [questionTypeAddState, setQuestionTypeAddState] = useState('')
+  const router = useRouter()
+  const courseId = router.query['cid']
+  const course = useCourse(Number(courseId))
   const [currentZoomLink, setCurrentZoomLink] = useState(
-    course.course?.zoomLink
-  );
-  const [zoomLink, setZoomLink] = useState("");
+    course.course?.zoomLink,
+  )
+  const [zoomLink, setZoomLink] = useState('')
   useEffect(() => {
-    getQuestions();
-  }, []);
+    getQuestions()
+  }, [])
 
   const editQueue = async (updateQueue: UpdateQueueParams) => {
-    const newQueue = { ...queue, ...updateQueue };
-    mutateQueue(newQueue, false);
+    const newQueue = { ...queue, ...updateQueue }
+    mutateQueue(newQueue, false)
     await API.queues.update(
       newQueue.id,
-      pick(newQueue, ["notes", "allowQuestions"])
-    );
-    mutateQueue();
-  };
+      pick(newQueue, ['notes', 'allowQuestions']),
+    )
+    mutateQueue()
+  }
 
-  const courseNumber = Number(courseId);
+  const courseNumber = Number(courseId)
   const getQuestions = async () => {
-    setQuestionsTypeState(await API.questions.questionTypes(courseNumber));
-  };
+    setQuestionsTypeState(await API.questions.questionTypes(courseNumber))
+  }
 
   const onclick = useCallback(
     async (s: string) => {
-      await API.questions.deleteQuestionType(courseNumber, s);
-      const temp = await API.questions.questionTypes(courseNumber);
-      await setQuestionsTypeState(temp);
+      await API.questions.deleteQuestionType(courseNumber, s)
+      const temp = await API.questions.questionTypes(courseNumber)
+      await setQuestionsTypeState(temp)
     },
-    [courseNumber]
-  );
+    [courseNumber],
+  )
 
-  const onAddChange = e => {
-    setQuestionTypeAddState(e.target.value);
-  };
-  const onZoomLinkChange = e => {
-    setZoomLink(e.target.value);
-  };
+  const onAddChange = (e) => {
+    setQuestionTypeAddState(e.target.value)
+  }
+  const onZoomLinkChange = (e) => {
+    setZoomLink(e.target.value)
+  }
   const addQuestionType = useCallback(async () => {
-    await API.questions.addQuestionType(courseNumber, questionTypeAddState);
-    setQuestionsTypeState(await API.questions.questionTypes(courseNumber));
-  }, [courseNumber, questionTypeAddState]);
+    await API.questions.addQuestionType(courseNumber, questionTypeAddState)
+    setQuestionsTypeState(await API.questions.questionTypes(courseNumber))
+  }, [courseNumber, questionTypeAddState])
   const changeZoomLink = async () => {
     await API.course
       .editCourseInfo(Number(courseId), {
         courseId: Number(courseId),
-        zoomLink: zoomLink
+        zoomLink: zoomLink,
       })
       .then(() => {
-        message.success("Zoom link Changed");
-        setCurrentZoomLink(zoomLink);
-      });
-  };
+        message.success('Zoom link Changed')
+        setCurrentZoomLink(zoomLink)
+      })
+  }
   return (
     <Modal
       title="Edit Queue Details"
       visible={visible}
       onCancel={onClose}
       onOk={async () => {
-        const value = await form.validateFields();
-        await editQueue(value);
-        onClose();
+        const value = await form.validateFields()
+        await editQueue(value)
+        onClose()
       }}
     >
       {queue && (
         <Form form={form} initialValues={queue}>
           <Form.Item label="Queue Notes" name="notes">
-            <NotesInput allowClear={true} placeholder={""} />
+            <NotesInput allowClear={true} placeholder={''} />
           </Form.Item>
           <Form.Item
             label="Allow New Questions"
             name="allowQuestions"
             valuePropName="checked"
           >
-            <Switch data-cy="allow-questions-toggle" />
+            <Switch
+              style={{ backgroundColor: '#1677ff' }}
+              data-cy="allow-questions-toggle"
+            />
           </Form.Item>
           <h4>Current Question Types: (click to delete)</h4>
           <Radio.Group buttonStyle="solid">
             {questionsTypeState.length > 0 ? (
-              questionsTypeState.map(q => (
+              questionsTypeState.map((q) => (
                 <Radio.Button onClick={() => onclick(q)} key={q} value={q}>
-                  {" "}
+                  {' '}
                   {q}
                 </Radio.Button>
               ))
@@ -125,16 +128,16 @@ export function EditQueueModal({
           <Form.Item label="Enter a new question type: " name="add">
             <Input
               allowClear={true}
-              placeholder={""}
+              placeholder={''}
               value={questionTypeAddState}
               onChange={onAddChange}
             />
             <Button onClick={addQuestionType}> Add </Button>
           </Form.Item>
-          <h4 style={{ marginTop: "20px" }}>
-            Current Zoom link:{" "}
+          <h4 style={{ marginTop: '20px' }}>
+            Current Zoom link:{' '}
             {currentZoomLink ? (
-              <p style={{ color: "blue" }}>{currentZoomLink} </p>
+              <p style={{ color: 'blue' }}>{currentZoomLink} </p>
             ) : (
               <p> Zoomlink not Available</p>
             )}
@@ -146,5 +149,5 @@ export function EditQueueModal({
         </Form>
       )}
     </Modal>
-  );
+  )
 }

--- a/packages/app/components/Settings/NotificationsSettings.tsx
+++ b/packages/app/components/Settings/NotificationsSettings.tsx
@@ -1,58 +1,58 @@
-import { MinusCircleOutlined, QuestionCircleOutlined } from "@ant-design/icons";
-import { API } from "@koh/api-client";
+import { MinusCircleOutlined, QuestionCircleOutlined } from '@ant-design/icons'
+import { API } from '@koh/api-client'
 import {
   DesktopNotifPartial,
   ERROR_MESSAGES,
   UpdateProfileParams,
-} from "@koh/common";
-import { Button, Form, List, message, Switch, Tooltip } from "antd";
-import { pick } from "lodash";
-import { HeaderTitle } from "./Styled";
-import React, { ReactElement, useEffect, useState } from "react";
-import styled from "styled-components";
-import useSWR from "swr";
+} from '@koh/common'
+import { Button, Form, List, message, Switch, Tooltip } from 'antd'
+import { pick } from 'lodash'
+import { HeaderTitle } from './Styled'
+import React, { ReactElement, useEffect, useState } from 'react'
+import styled from 'styled-components'
+import useSWR from 'swr'
 import {
   getEndpoint,
   getNotificationState,
   NotificationStates,
   registerNotificationSubscription,
   requestNotificationPermission,
-} from "../../utils/notification";
+} from '../../utils/notification'
 
 const DeviceAddHeader = styled.div`
   display: flex;
   justify-content: space-between;
-`;
+`
 
 export default function NotificationsSettings(): ReactElement {
   const { data: profile, mutate } = useSWR(`api/v1/profile`, async () =>
-    API.profile.index()
-  );
+    API.profile.index(),
+  )
 
-  const [form] = Form.useForm();
+  const [form] = Form.useForm()
 
   const editProfile = async (updateProfile: UpdateProfileParams) => {
-    const newProfile = { ...profile, ...updateProfile };
-    mutate(newProfile, false);
+    const newProfile = { ...profile, ...updateProfile }
+    mutate(newProfile, false)
     await API.profile.patch(
       pick(newProfile, [
-        "desktopNotifsEnabled",
-        "phoneNotifsEnabled",
-        "phoneNumber",
-      ])
-    );
-    mutate();
-    return newProfile;
-  };
+        'desktopNotifsEnabled',
+        'phoneNotifsEnabled',
+        'phoneNumber',
+      ]),
+    )
+    mutate()
+    return newProfile
+  }
 
   const handleOk = async () => {
-    const value = await form.validateFields();
+    const value = await form.validateFields()
     try {
-      const newProfile = await editProfile(value);
-      form.setFieldsValue(newProfile);
+      const newProfile = await editProfile(value)
+      form.setFieldsValue(newProfile)
       message.success(
-        "Your notification settings have been successfully updated"
-      );
+        'Your notification settings have been successfully updated',
+      )
     } catch (e) {
       if (
         e.response?.status === 400 &&
@@ -60,11 +60,11 @@ export default function NotificationsSettings(): ReactElement {
           ERROR_MESSAGES.notificationService.registerPhone
       ) {
         form.setFields([
-          { name: "phoneNumber", errors: ["Invalid phone number"] },
-        ]);
+          { name: 'phoneNumber', errors: ['Invalid phone number'] },
+        ])
       }
     }
-  };
+  }
 
   return (
     profile && (
@@ -79,21 +79,21 @@ export default function NotificationsSettings(): ReactElement {
             name="desktopNotifsEnabled"
             valuePropName="checked"
           >
-            <Switch />
+            <Switch style={{ backgroundColor: '#1677ff' }} />
           </Form.Item>
           <Form.Item shouldUpdate noStyle>
             {() =>
-              form?.getFieldValue("desktopNotifsEnabled") && (
+              form?.getFieldValue('desktopNotifsEnabled') && (
                 <DeviceNotifPanel />
               )
             }
           </Form.Item>
           <Tooltip title="Notification still doesn't work? Click here!">
             <QuestionCircleOutlined
-              style={{ marginTop: "30px", float: "right", fontSize: "25px" }}
+              style={{ marginTop: '30px', float: 'right', fontSize: '25px' }}
               onClick={() =>
                 window.open(
-                  "https://www.makeuseof.com/google-chrome-notifications-not-working-fixes/"
+                  'https://www.makeuseof.com/google-chrome-notifications-not-working-fixes/',
                 )
               }
             />
@@ -140,42 +140,42 @@ export default function NotificationsSettings(): ReactElement {
           key="submit"
           type="primary"
           onClick={handleOk}
-          style={{ marginTop: "30px", marginBottom: "15px" }}
+          style={{ marginTop: '30px', marginBottom: '15px' }}
         >
           Save
         </Button>
       </>
     )
-  );
+  )
 }
 
 function useThisDeviceEndpoint(): null | string {
-  const [endpoint, setEndpoint] = useState(null);
+  const [endpoint, setEndpoint] = useState(null)
   useEffect(() => {
-    (async () => setEndpoint(await getEndpoint()))();
-  });
-  return endpoint;
+    ;(async () => setEndpoint(await getEndpoint()))()
+  })
+  return endpoint
 }
 
 function renderDeviceInfo(
   device: DesktopNotifPartial,
-  isThisDevice: boolean
+  isThisDevice: boolean,
 ): string {
   if (device.name) {
-    return isThisDevice ? `${device.name} (This Device)` : device.name;
+    return isThisDevice ? `${device.name} (This Device)` : device.name
   } else {
-    return isThisDevice ? "This Device" : "Other Device";
+    return isThisDevice ? 'This Device' : 'Other Device'
   }
 }
 
 function DeviceNotifPanel() {
-  const thisEndpoint = useThisDeviceEndpoint();
+  const thisEndpoint = useThisDeviceEndpoint()
   const { data: profile, mutate } = useSWR(`api/v1/profile`, async () =>
-    API.profile.index()
-  );
+    API.profile.index(),
+  )
   const thisDesktopNotif = profile?.desktopNotifs?.find(
-    (dn) => dn.endpoint === thisEndpoint
-  );
+    (dn) => dn.endpoint === thisEndpoint,
+  )
   return (
     <div>
       <DeviceAddHeader>
@@ -185,24 +185,24 @@ function DeviceNotifPanel() {
             title={
               getNotificationState() ===
                 NotificationStates.browserUnsupported &&
-              "Browser does not support notifications. Please use Chrome or Firefox, and not Incognito Mode."
+              'Browser does not support notifications. Please use Chrome or Firefox, and not Incognito Mode.'
             }
           >
             <Button
               onClick={async () => {
-                const canNotify = await requestNotificationPermission();
+                const canNotify = await requestNotificationPermission()
                 if (canNotify === NotificationStates.notAllowed) {
-                  message.warning("Please allow notifications in this browser");
+                  message.warning('Please allow notifications in this browser')
                 }
                 if (canNotify === NotificationStates.granted) {
-                  await registerNotificationSubscription();
-                  mutate();
+                  await registerNotificationSubscription()
+                  mutate()
                 }
               }}
               disabled={
                 getNotificationState() === NotificationStates.browserUnsupported
               }
-              style={{ marginBottom: "4px" }}
+              style={{ marginBottom: '4px' }}
             >
               Add This Device
             </Button>
@@ -212,16 +212,16 @@ function DeviceNotifPanel() {
       <List
         bordered
         dataSource={profile.desktopNotifs}
-        locale={{ emptyText: "No Devices Registered To Receive Notifications" }}
+        locale={{ emptyText: 'No Devices Registered To Receive Notifications' }}
         renderItem={(device: DesktopNotifPartial) => (
           <List.Item
             actions={[
               <MinusCircleOutlined
-                style={{ fontSize: "20px" }}
+                style={{ fontSize: '20px' }}
                 key={0}
                 onClick={async () => {
-                  await API.notif.desktop.unregister(device.id);
-                  mutate();
+                  await API.notif.desktop.unregister(device.id)
+                  mutate()
                 }}
               />,
             ]}
@@ -234,5 +234,5 @@ function DeviceNotifPanel() {
         )}
       />
     </div>
-  );
+  )
 }

--- a/packages/app/components/Settings/TeamsSettings.tsx
+++ b/packages/app/components/Settings/TeamsSettings.tsx
@@ -1,34 +1,34 @@
-import { API } from "@koh/api-client";
-import { UpdateProfileParams } from "@koh/common";
-import { Button, Col, Form, Input, message, Switch } from "antd";
-import { pick } from "lodash";
-import { HeaderTitle } from "./Styled";
-import React, { ReactElement } from "react";
-import useSWR from "swr";
+import { API } from '@koh/api-client'
+import { UpdateProfileParams } from '@koh/common'
+import { Button, Col, Form, Input, message, Switch } from 'antd'
+import { pick } from 'lodash'
+import { HeaderTitle } from './Styled'
+import React, { ReactElement } from 'react'
+import useSWR from 'swr'
 
 export default function TeamsSettings(): ReactElement {
-  const { TextArea } = Input;
+  const { TextArea } = Input
   const { data: profile, mutate } = useSWR(`api/v1/profile`, async () =>
-    API.profile.index()
-  );
+    API.profile.index(),
+  )
 
-  const [form] = Form.useForm();
+  const [form] = Form.useForm()
   const editProfile = async (updateProfile: UpdateProfileParams) => {
-    const newProfile = { ...profile, ...updateProfile };
-    mutate(newProfile, false);
+    const newProfile = { ...profile, ...updateProfile }
+    mutate(newProfile, false)
     await API.profile.patch(
-      pick(newProfile, ["defaultMessage", "includeDefaultMessage"])
-    );
-    mutate();
-    return newProfile;
-  };
+      pick(newProfile, ['defaultMessage', 'includeDefaultMessage']),
+    )
+    mutate()
+    return newProfile
+  }
 
   const handleOk = async () => {
-    const value = await form.validateFields();
-    const newProfile = await editProfile(value);
-    form.setFieldsValue(newProfile);
-    message.success("Your profile settings have been successfully updated");
-  };
+    const value = await form.validateFields()
+    const newProfile = await editProfile(value)
+    form.setFieldsValue(newProfile)
+    message.success('Your profile settings have been successfully updated')
+  }
 
   return profile ? (
     <div>
@@ -42,11 +42,11 @@ export default function TeamsSettings(): ReactElement {
             name="includeDefaultMessage"
             valuePropName="checked"
           >
-            <Switch />
+            <Switch style={{ backgroundColor: '#1677ff' }} />
           </Form.Item>
-          <Form.Item shouldUpdate noStyle style={{ marginTop: "30px" }}>
+          <Form.Item shouldUpdate noStyle style={{ marginTop: '30px' }}>
             {() =>
-              form?.getFieldValue("includeDefaultMessage") && (
+              form?.getFieldValue('includeDefaultMessage') && (
                 <Form.Item
                   label="Default Teams Message"
                   name="defaultMessage"
@@ -55,7 +55,7 @@ export default function TeamsSettings(): ReactElement {
                     {
                       required: true,
                       message:
-                        "Please input your default message for Teams chat!",
+                        'Please input your default message for Teams chat!',
                     },
                   ]}
                 >
@@ -64,7 +64,7 @@ export default function TeamsSettings(): ReactElement {
                     placeholder={
                       profile?.defaultMessage
                         ? profile?.defaultMessage
-                        : "Enter Your Message Here"
+                        : 'Enter Your Message Here'
                     }
                   />
                 </Form.Item>
@@ -77,10 +77,10 @@ export default function TeamsSettings(): ReactElement {
         key="submit"
         type="primary"
         onClick={handleOk}
-        style={{ marginBottom: "15px" }}
+        style={{ marginBottom: '15px' }}
       >
         Save
       </Button>
     </div>
-  ) : null;
+  ) : null
 }

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -1,9 +1,8 @@
 import { API } from '@koh/api-client'
 import { QueuePartial, Role } from '@koh/common'
-import { Button, message } from 'antd'
+import { message } from 'antd'
 import { useRouter } from 'next/router'
 import React, { ReactElement, useState } from 'react'
-import styled from 'styled-components'
 import { useCourse } from '../../hooks/useCourse'
 import { useProfile } from '../../hooks/useProfile'
 import { useRoleInCourse } from '../../hooks/useRoleInCourse'
@@ -11,20 +10,17 @@ import QueueCheckInModal from './QueueCheckInModal'
 import QueueCreateModal from './QueueCreateModal'
 import TACheckinButton, { CheckinButton } from './TACheckinButton'
 
-const CreateQueueButton = styled(Button)`
-  color: white;
-  background: #2a9187;
-  &:hover,
-  &:focus {
-    color: white;
-    background: #39aca1;
-  }
-`
+interface TodayPageCheckinButtonProps {
+  createQueueModalVisible: boolean
+  setCreateQueueModalVisible: React.Dispatch<React.SetStateAction<boolean>>
+}
 
-export default function TodayPageCheckinButton(): ReactElement {
+export default function TodayPageCheckinButton({
+  createQueueModalVisible,
+  setCreateQueueModalVisible,
+}: TodayPageCheckinButtonProps): ReactElement {
   // state for check in modal
   const [checkInModalVisible, setCheckInModalVisible] = useState(false)
-  const [createQueueModalVisible, setCreateQueueModalVisible] = useState(false)
 
   const profile = useProfile()
   const router = useRouter()
@@ -55,37 +51,13 @@ export default function TodayPageCheckinButton(): ReactElement {
         !queueRequest.allowTA,
         queueRequest.notes,
       )
-      message.success(
-        `Created a new queue ${queueRequest.officeHourName}. Checking you in...`,
-      )
-      const redirectID = await API.taStatus.checkIn(
-        Number(cid),
-        queueRequest.officeHourName,
-      )
-
+      message.success(`Created a new queue ${queueRequest.officeHourName}`)
       mutateCourse()
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const checkoutTimer = setTimeout(
-        async () => {
-          message.warning('You are checked out automatically after 3 hours')
-          await API.taStatus.checkOut(Number(cid), queueRequest.officeHourName)
-          mutateCourse()
-        },
-        1000 * 60 * 60 * 3,
-      )
-      router.push(
-        '/course/[cid]/queue/[qid]',
-        `/course/${Number(cid)}/queue/${redirectID.id}`,
-      )
+
       setCreateQueueModalVisible(false)
     } catch (err) {
       message.error(err.response?.data?.message)
     }
-  }
-
-  const onCreateQueueButtonClick = () => {
-    setCheckInModalVisible(false)
-    setCreateQueueModalVisible(true)
   }
 
   return (
@@ -124,11 +96,6 @@ export default function TodayPageCheckinButton(): ReactElement {
             }
           }}
           onCancel={() => setCheckInModalVisible(false)}
-          button={
-            <CreateQueueButton onClick={onCreateQueueButtonClick}>
-              + Create Queue
-            </CreateQueueButton>
-          }
           queues={availableQueues}
         />
       )}

--- a/packages/app/components/Today/QueueCreateModal.tsx
+++ b/packages/app/components/Today/QueueCreateModal.tsx
@@ -1,16 +1,16 @@
-import { Role } from "@koh/common";
-import { Modal, Form, Switch, Radio, Input } from "antd";
-import { FormInstance } from "antd/lib/form";
-import TextArea from "antd/lib/input/TextArea";
-import { ReactElement } from "react";
-import { useState } from "react";
+import { Role } from '@koh/common'
+import { Modal, Form, Switch, Radio, Input } from 'antd'
+import { FormInstance } from 'antd/lib/form'
+import TextArea from 'antd/lib/input/TextArea'
+import { ReactElement } from 'react'
+import { useState } from 'react'
 
 interface QueueCreateModalProps {
-  visible: boolean;
-  onSubmit: (form: FormInstance) => void;
-  onCancel: () => void;
-  role: Role;
-  lastName: string;
+  visible: boolean
+  onSubmit: (form: FormInstance) => void
+  onCancel: () => void
+  role: Role
+  lastName: string
 }
 
 export default function QueueCreateModal({
@@ -20,33 +20,33 @@ export default function QueueCreateModal({
   role,
   lastName,
 }: QueueCreateModalProps): ReactElement {
-  const [form] = Form.useForm();
+  const [form] = Form.useForm()
   const [locEditable, setLocEditable] = useState(
-    !form.getFieldValue("isOnline")
-  );
+    !form.getFieldValue('isOnline'),
+  )
 
   const onIsOnlineUpdate = (isOnline) => {
-    setLocEditable(!isOnline);
+    setLocEditable(!isOnline)
     if (!isOnline) {
       form.setFieldsValue({
-        officeHourName: "",
-      });
+        officeHourName: '',
+      })
     } else {
-      updateRoomName();
+      updateRoomName()
     }
-  };
+  }
 
   const updateRoomName = () => {
-    const online = form.getFieldValue("isOnline");
-    const allowTA = form.getFieldValue("allowTA");
+    const online = form.getFieldValue('isOnline')
+    const allowTA = form.getFieldValue('allowTA')
     if (online) {
       form.setFieldsValue({
         officeHourName: allowTA
           ? `Online`
           : `Online - Professor ${lastName}'s Office Hours`,
-      });
+      })
     }
-  };
+  }
 
   return (
     <Modal
@@ -64,7 +64,11 @@ export default function QueueCreateModal({
           valuePropName="checked"
           tooltip="Online queues automatically open a Teams chat when helping a student"
         >
-          <Switch data-cy="qc-isonline" onChange={onIsOnlineUpdate} />
+          <Switch
+            style={{ backgroundColor: '#1677ff' }}
+            data-cy="qc-isonline"
+            onChange={onIsOnlineUpdate}
+          />
         </Form.Item>
 
         <Form.Item
@@ -89,13 +93,13 @@ export default function QueueCreateModal({
           rules={[
             {
               required: true,
-              message: "Please give this room a name.",
+              message: 'Please give this room a name.',
             },
           ]}
         >
           <Input
             data-cy="qc-location"
-            placeholder={"Ex: ISEC 102"}
+            placeholder={'Ex: ISEC 102'}
             disabled={!locEditable}
             style={{ width: 350 }}
           />
@@ -104,11 +108,11 @@ export default function QueueCreateModal({
         <Form.Item
           label={<strong>Additional Notes (optional)</strong>}
           name="notes"
-          style={{ width: "100%" }}
+          style={{ width: '100%' }}
         >
           <TextArea data-cy="qc-notes" rows={4} placeholder="Notes" />
         </Form.Item>
       </Form>
     </Modal>
-  );
+  )
 }

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -27,8 +27,14 @@ const Container = styled.div`
 
 const Title = styled.div`
   font-weight: 500;
-  font-size: 30px;
+  font-size: 1.5em; /* Mobile devices */
   color: #212934;
+  white-space: nowrap;
+  overflow: hidden;
+
+  @media (min-width: 768px) {
+    font-size: 2em; /* Desktop devices */
+  }
 `
 
 const TodayCol = styled(Col)`

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -1,11 +1,11 @@
 import { API } from '@koh/api-client'
 import { Heatmap, QueuePartial, Role } from '@koh/common'
-import { Col, Row, Spin } from 'antd'
+import { Col, Row, Spin, Button } from 'antd'
 import { chunk, mean } from 'lodash'
 import moment from 'moment'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import React, { ReactElement, useEffect } from 'react'
+import React, { ReactElement, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { StandardPageContainer } from '../../../components/common/PageContainer'
 import NavBar from '../../../components/Nav/NavBar'
@@ -40,6 +40,16 @@ const RoleColorSpan = styled.span`
   font-weight: bold;
 `
 
+export const CreateQueueButton = styled(Button)`
+  background: #1890ff;
+  border-radius: 6px;
+  color: white;
+  font-weight: 500;
+  font-size: 14px;
+  margin: auto;
+  padding: 0.25em 1em;
+`
+
 function roleToString(role: Role) {
   switch (role) {
     case Role.TA:
@@ -72,6 +82,7 @@ export default function Today(): ReactElement {
   const { cid } = router.query
   const role = useRoleInCourse(Number(cid))
   const { course, mutateCourse } = useCourse(Number(cid))
+  const [createQueueModalVisible, setCreateQueueModalVisible] = useState(false)
 
   useEffect(() => {
     setOpen(true)
@@ -118,8 +129,11 @@ export default function Today(): ReactElement {
           <Row gutter={64}>
             <TodayCol md={12} xs={24}>
               <Row justify="space-between">
-                <Title>Current Office Hours</Title>
-                <TodayPageCheckinButton />
+                <Title>{course?.name} Help Centre</Title>
+                <TodayPageCheckinButton
+                  createQueueModalVisible={createQueueModalVisible}
+                  setCreateQueueModalVisible={setCreateQueueModalVisible}
+                />
               </Row>
               <Row>
                 <div>
@@ -150,7 +164,13 @@ export default function Today(): ReactElement {
               )}
               {!course && <QueueCardSkeleton />}
               <AsyncQuestionCard></AsyncQuestionCard>
-
+              <Row>
+                <CreateQueueButton
+                  onClick={() => setCreateQueueModalVisible(true)}
+                >
+                  + Create Queue
+                </CreateQueueButton>
+              </Row>
               {
                 // This only works with UTC offsets in the form N:00, to help with other offsets, the size of the array might have to change to a size of 24*7*4 (for every 15 min interval)
                 course && course.heatmap && (


### PR DESCRIPTION
# Description

- Moved the "Create Queue" button from outside the checkin modal and onto the main course page, just below the list of queues (screenshots in discord). I had to remove functionality from the create queue button so that it doesn't automatically check you in at the same time
- Title on course page: "Current Office Hours" -> "{course?.name} Help Centre"

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual Testing. 
I made sure that the current checkin button still works as expected. I tried creating several different queues using the new button to see if it works as expected. I also tried to see how it looks like on mobile and it still looks okay.

![image](https://github.com/ubco-db/office-hours/assets/13655728/a071ae42-c7cf-4b83-8869-96b960c6cfc5)



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
