### PR TITLE
Chatbot UI Height Quickfix

### DIFF
--- a/packages/app/components/Chatbot/Chatbot.tsx
+++ b/packages/app/components/Chatbot/Chatbot.tsx
@@ -195,13 +195,13 @@ export const ChatbotComponent: React.FC = () => {
     return <></>
   }
   return (
-    <ChatbotContainer style={{ zIndex: 1000 }}>
+    <ChatbotContainer className="max-h-[90vh]" style={{ zIndex: 1000 }}>
       {isOpen ? (
         <Card
           title="CS304 chatbot"
           extra={<a onClick={() => setIsOpen(false)}>Close</a>}
         >
-          <div className="max-h-[700px] overflow-y-auto">
+          <div className="max-h-[70vh] overflow-y-auto">
             {messages &&
               messages.map((item) => (
                 <>


### PR DESCRIPTION
2 line code change to make the max height of the chatbot to be based on viewport height rather than a fixed 700 px

![image](https://github.com/ubco-db/office-hours/assets/13655728/1bfc39a5-cc77-4d82-8ac4-49b82f8f84e1)
(the fix)

![image](https://github.com/ubco-db/office-hours/assets/13655728/ef924c2a-1321-4dc6-9e1a-b401e7606ebb)
(mobile UI basically unchanged)