### PR TITLE
[HOTFIX] fixed broken mobile nav and student create queue

### DIFF
--- a/packages/app/components/Nav/NavBar.tsx
+++ b/packages/app/components/Nav/NavBar.tsx
@@ -246,7 +246,7 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
           onClose={onClose}
           bodyStyle={{ padding: '12px' }}
         >
-          <NavBarTabs currentHref={pathname} tabs={tabs} />
+          <NavBarTabs currentHref={pathname} tabs={tabs} hrefAsPath={asPath} />
           <ProfileDrawer courseId={courseId} />
         </Drawer>
       </Nav>
@@ -273,7 +273,12 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
         </LogoContainer>
         <MenuCon>
           <LeftMenu>
-            <NavBarTabs horizontal currentHref={pathname} tabs={globalTabs} />
+            <NavBarTabs
+              horizontal
+              currentHref={pathname}
+              tabs={globalTabs}
+              hrefAsPath={asPath}
+            />
           </LeftMenu>
           <RightMenu>
             <ProfileDrawer />
@@ -290,7 +295,11 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
           onClose={onClose}
           bodyStyle={{ padding: '12px' }}
         >
-          <NavBarTabs currentHref={pathname} tabs={globalTabs} />
+          <NavBarTabs
+            currentHref={pathname}
+            tabs={globalTabs}
+            hrefAsPath={asPath}
+          />
           <ProfileDrawer courseId={null} />
         </Drawer>
       </Nav>

--- a/packages/app/components/Nav/NavBarTabs.tsx
+++ b/packages/app/components/Nav/NavBarTabs.tsx
@@ -75,7 +75,7 @@ function createQueueTab(queueTabItem: NavBarQueueTabItem, currentPath: string) {
       data-cy="queue-tab"
       title="Queue"
       className={
-        currentPath.includes(`/course/${queueTabItem.courseId}/queue/`)
+        currentPath?.includes(`/course/${queueTabItem.courseId}/queue/`)
           ? 'ant-menu-item-selected'
           : ''
       }

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -161,13 +161,15 @@ export default function Today(): ReactElement {
               )}
               {!course && <QueueCardSkeleton />}
               <AsyncQuestionCard></AsyncQuestionCard>
-              <Row>
-                <CreateQueueButton
-                  onClick={() => setCreateQueueModalVisible(true)}
-                >
-                  + Create Queue
-                </CreateQueueButton>
-              </Row>
+              {role !== Role.STUDENT && (
+                <Row>
+                  <CreateQueueButton
+                    onClick={() => setCreateQueueModalVisible(true)}
+                  >
+                    + Create Queue
+                  </CreateQueueButton>
+                </Row>
+              )}
               {
                 // This only works with UTC offsets in the form N:00, to help with other offsets, the size of the array might have to change to a size of 24*7*4 (for every 15 min interval)
                 course && course.heatmap && (


### PR DESCRIPTION
# Description

- Fixed mobile navbar crash
	- Mobile navbar would crash when trying to load due to some navbars not passing in the new 'hrefaspath' parameter, which is used for highlighting the current queue you are in. I made this parameter properly optional now and also fixed it by adding the hrefaspath in the other calls of navbartabs.
- Made "Create Queue" button not show up for students. 

Closes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

Manual testing. Made sure create queue still works for professors and not show up for students. 

Made sure that the mobile navbar appears correctly and without crashes.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
