### PR TITLE
UI improvements

### DIFF
--- a/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
+++ b/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
@@ -1,32 +1,32 @@
-import { Button, Card, Divider, Row, Skeleton, Space } from "antd";
-import Link from "next/link";
-import { useRouter } from "next/router";
-import React, { ReactElement } from "react";
-import styled from "styled-components";
+import { Button, Card, Divider, Row, Skeleton, Space } from 'antd'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import React, { ReactElement } from 'react'
+import styled from 'styled-components'
 
 const PaddedCard = styled(Card)`
   margin-top: 32px;
   margin-bottom: 25px;
   border-radius: 6px;
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
-`;
+`
 
 const HeaderDiv = styled.div`
   font-size: 18px;
   color: #212934;
-`;
+`
 
 const QueueInfoRow = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-`;
+`
 
 const RightQueueInfoRow = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-`;
+`
 
 const OpenQueueButton = styled(Button)`
   color: #5f6b79;
@@ -34,35 +34,34 @@ const OpenQueueButton = styled(Button)`
   font-weight: 500;
   font-size: 14px;
   margin-left: 16px;
-`;
+`
 
 const QueueCardDivider = styled(Divider)`
   margin-top: 12px;
   margin-bottom: 0;
-`;
+`
 
 const NotesSkeleton = styled(Skeleton)`
   width: 60%;
-`;
+`
 
 const AsyncQuestionCard = (): ReactElement => {
-  const router = useRouter();
-  const { cid } = router.query;
+  const router = useRouter()
+  const { cid } = router.query
   return (
     <PaddedCard
       headStyle={{
-        background: "#25426C",
-        color: "#FFFFFF",
-        borderRadius: "6px 6px 0 0",
+        background: '#25426C',
+        color: '#FFFFFF',
+        borderRadius: '6px 6px 0 0',
       }}
-      className={"open-queue-card"}
-      title="Async Question center"
+      className={'open-queue-card'}
+      title="Async Question Centre"
       extra={<span>Ask your questions any time!</span>}
     >
       <QueueInfoRow>
         <HeaderDiv>
           {/* <QuestionNumberSpan>{queue.staffList.length}</QuestionNumberSpan>{" "} */}
-          staff checked in
         </HeaderDiv>
         <RightQueueInfoRow>
           <Space direction="vertical" align="end" size="middle">
@@ -70,10 +69,7 @@ const AsyncQuestionCard = (): ReactElement => {
               href="/course/[cid]/async_question"
               as={`/course/${cid}/async_question`}
             >
-              <OpenQueueButton
-                style={{}}
-                size="large"
-              >
+              <OpenQueueButton style={{}} size="large">
                 Open Queue
               </OpenQueueButton>
             </Link>
@@ -83,20 +79,20 @@ const AsyncQuestionCard = (): ReactElement => {
 
       <Row justify="space-between" align="middle"></Row>
     </PaddedCard>
-  );
-};
+  )
+}
 
-export default AsyncQuestionCard;
+export default AsyncQuestionCard
 
 export function QueueCardSkeleton(): ReactElement {
   return (
     <PaddedCard
       headStyle={{
-        background: "#25426C",
-        color: "#FFFFFF",
-        borderRadius: "6px 6px 0 0",
+        background: '#25426C',
+        color: '#FFFFFF',
+        borderRadius: '6px 6px 0 0',
       }}
-      className={"open-queue-card"}
+      className={'open-queue-card'}
       title={<Skeleton title={false} paragraph={{ rows: 1 }} />}
     >
       <QueueInfoRow>
@@ -107,8 +103,8 @@ export function QueueCardSkeleton(): ReactElement {
       <QueueCardDivider />
       <Row justify="space-between" align="bottom">
         <NotesSkeleton title={false} paragraph={{ rows: 1 }} />
-        <Skeleton.Button size="large" style={{ marginTop: "12px" }} />
+        <Skeleton.Button size="large" style={{ marginTop: '12px' }} />
       </Row>
     </PaddedCard>
-  );
+  )
 }

--- a/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
+++ b/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
@@ -1,5 +1,5 @@
 import { RightOutlined } from '@ant-design/icons'
-import { Button, Card, Divider, Row, Skeleton, Space } from 'antd'
+import { Card, Divider, Row, Skeleton } from 'antd'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import React, { ReactElement } from 'react'
@@ -25,10 +25,9 @@ const CustomCard = styled(Card)`
   transition: box-shadow 0.3s ease;
   &:hover {
     box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.45);
-    // background: rgba(235, 235, 235);
 
     .ant-card-head {
-      background: rgb(47, 76, 128) !important;
+      background: rgb(70, 76, 121) !important;
       transition: color 0.3s ease-in-out !important;
     }
 
@@ -66,7 +65,7 @@ const AsyncQuestionCard = (): ReactElement => {
     >
       <CustomCard
         headStyle={{
-          background: '#25426C',
+          background: 'rgb(60, 66, 111)',
           color: '#FFFFFF',
           borderRadius: '6px 6px 0 0',
         }}
@@ -75,10 +74,7 @@ const AsyncQuestionCard = (): ReactElement => {
         extra={<RightOutlined className=" text-3xl text-gray-100" />}
       >
         <QueueInfoRow>
-          <h4 className="italic text-gray-600">
-            {' '}
-            Ask your questions any time!
-          </h4>
+          <h4 className="italic text-gray-600">Ask your questions any time!</h4>
         </QueueInfoRow>
 
         <Row justify="space-between" align="middle"></Row>

--- a/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
+++ b/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
@@ -1,37 +1,50 @@
+import { RightOutlined } from '@ant-design/icons'
 import { Button, Card, Divider, Row, Skeleton, Space } from 'antd'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 
-const PaddedCard = styled(Card)`
+const CustomCard = styled(Card)`
   margin-top: 32px;
   margin-bottom: 25px;
   border-radius: 6px;
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
-`
 
-const HeaderDiv = styled.div`
-  font-size: 18px;
-  color: #212934;
+  // make the box shadow more pronounced on mobile to make it look more clickable
+  @media (max-width: 650px) {
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .ant-card-body {
+    padding-top: 16px;
+  }
+
+  // hover effect
+  cursor: pointer;
+  transition: box-shadow 0.3s ease;
+  &:hover {
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.45);
+    // background: rgba(235, 235, 235);
+
+    .ant-card-head {
+      background: rgb(47, 76, 128) !important;
+      transition: color 0.3s ease-in-out !important;
+    }
+
+    // make the green arrow right on hover (still uncertain on whether to keep this)
+    .anticon.anticon-right {
+      color: lightgreen;
+      transition: color 0.3s ease-in-out;
+    }
+  }
 `
 
 const QueueInfoRow = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-`
-
-const RightQueueInfoRow = styled.div`
-  display: flex;
-  flex-direction: row;
   align-items: center;
-`
-
-const OpenQueueButton = styled(Button)`
-  border-radius: 6px;
-  font-size: 14px;
-  margin-left: 16px;
 `
 
 const QueueCardDivider = styled(Divider)`
@@ -47,36 +60,30 @@ const AsyncQuestionCard = (): ReactElement => {
   const router = useRouter()
   const { cid } = router.query
   return (
-    <PaddedCard
-      headStyle={{
-        background: '#25426C',
-        color: '#FFFFFF',
-        borderRadius: '6px 6px 0 0',
-      }}
-      className={'open-queue-card'}
-      title="Async Question Centre"
-      extra={<span>Ask your questions any time!</span>}
+    <Link
+      href="/course/[cid]/async_question"
+      as={`/course/${cid}/async_question`}
     >
-      <QueueInfoRow>
-        <HeaderDiv>
-          {/* <QuestionNumberSpan>{queue.staffList.length}</QuestionNumberSpan>{" "} */}
-        </HeaderDiv>
-        <RightQueueInfoRow>
-          <Space direction="vertical" align="end" size="middle">
-            <Link
-              href="/course/[cid]/async_question"
-              as={`/course/${cid}/async_question`}
-            >
-              <OpenQueueButton type="primary" size="large">
-                Open Queue ＞
-              </OpenQueueButton>
-            </Link>
-          </Space>
-        </RightQueueInfoRow>
-      </QueueInfoRow>
+      <CustomCard
+        headStyle={{
+          background: '#25426C',
+          color: '#FFFFFF',
+          borderRadius: '6px 6px 0 0',
+        }}
+        className={'open-queue-card'}
+        title="Async Question Centre"
+        extra={<RightOutlined className=" text-3xl text-gray-100" />}
+      >
+        <QueueInfoRow>
+          <h4 className="italic text-gray-600">
+            {' '}
+            Ask your questions any time!
+          </h4>
+        </QueueInfoRow>
 
-      <Row justify="space-between" align="middle"></Row>
-    </PaddedCard>
+        <Row justify="space-between" align="middle"></Row>
+      </CustomCard>
+    </Link>
   )
 }
 
@@ -84,7 +91,7 @@ export default AsyncQuestionCard
 
 export function QueueCardSkeleton(): ReactElement {
   return (
-    <PaddedCard
+    <CustomCard
       headStyle={{
         background: '#25426C',
         color: '#FFFFFF',
@@ -103,6 +110,6 @@ export function QueueCardSkeleton(): ReactElement {
         <NotesSkeleton title={false} paragraph={{ rows: 1 }} />
         <Skeleton.Button size="large" style={{ marginTop: '12px' }} />
       </Row>
-    </PaddedCard>
+    </CustomCard>
   )
 }

--- a/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
+++ b/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
@@ -68,7 +68,7 @@ const AsyncQuestionCard = (): ReactElement => {
               as={`/course/${cid}/async_question`}
             >
               <OpenQueueButton type="primary" size="large">
-                Open Queue
+                Open Queue ＞
               </OpenQueueButton>
             </Link>
           </Space>

--- a/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
+++ b/packages/app/components/AsyncQuestion/AsyncQuestionCard.tsx
@@ -29,9 +29,7 @@ const RightQueueInfoRow = styled.div`
 `
 
 const OpenQueueButton = styled(Button)`
-  color: #5f6b79;
   border-radius: 6px;
-  font-weight: 500;
   font-size: 14px;
   margin-left: 16px;
 `
@@ -69,7 +67,7 @@ const AsyncQuestionCard = (): ReactElement => {
               href="/course/[cid]/async_question"
               as={`/course/${cid}/async_question`}
             >
-              <OpenQueueButton style={{}} size="large">
+              <OpenQueueButton type="primary" size="large">
                 Open Queue
               </OpenQueueButton>
             </Link>

--- a/packages/app/components/Chatbot/Chatbot.tsx
+++ b/packages/app/components/Chatbot/Chatbot.tsx
@@ -49,7 +49,8 @@ export const ChatbotComponent: React.FC = () => {
   const [messages, setMessages] = useState<Message[]>([
     {
       type: 'apiMessage',
-      message: 'Hello, how can I assist you? I can help with anything course related.',
+      message:
+        'Hello, how can I assist you? I can help with anything course related.',
     },
   ])
   const [isOpen, setIsOpen] = useState(false)
@@ -288,6 +289,7 @@ export const ChatbotComponent: React.FC = () => {
           type="primary"
           icon={<RobotOutlined />}
           size="large"
+          className="mx-5"
           onClick={() => setIsOpen(true)}
         >
           Chat now!

--- a/packages/app/components/Chatbot/Chatbot.tsx
+++ b/packages/app/components/Chatbot/Chatbot.tsx
@@ -11,7 +11,8 @@ const ChatbotContainer = styled.div`
   position: fixed;
   bottom: 20px;
   right: 20px;
-  width: 400px;
+  width: 90vw;
+  max-width: 400px;
   zindex: 9999;
 `
 

--- a/packages/app/components/Nav/NavBar.tsx
+++ b/packages/app/components/Nav/NavBar.tsx
@@ -76,7 +76,6 @@ const RightMenu = styled.div`
 const BarsMenu = styled(Button)`
   height: 32px;
   padding: 6px;
-  margin-top: 8px;
   display: none;
   background: none;
 
@@ -91,6 +90,7 @@ const BarsButton = styled.span`
   height: 2px;
   background: #1890ff;
   position: relative;
+  margin-bottom: 5px;
 
   &:after,
   :before {
@@ -260,7 +260,25 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
           <BarsButton />
         </BarsMenu>
         <Drawer
-          title="Course"
+          // put the organisation logo and name into the drawer title
+          title={
+            course?.organizationCourse && (
+              <span className="flex items-center ">
+                <LogoContainer>
+                  <Logo>
+                    <Image
+                      width={30}
+                      preview={false}
+                      src={`/api/v1/organization/${profile?.organization.orgId}/get_logo/${profile?.organization.organizationLogoUrl}`}
+                    />
+                  </Logo>
+                </LogoContainer>
+                <h1 className="text-2xl leading-none">
+                  {profile?.organization.organizationName}
+                </h1>
+              </span>
+            )
+          }
           placement="right"
           open={visible}
           closable={false}
@@ -325,6 +343,7 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
             currentHref={pathname}
             tabs={globalTabs}
             hrefAsPath={asPath}
+            onClose={onClose}
           />
           <ProfileDrawer courseId={null} />
         </Drawer>

--- a/packages/app/components/Nav/NavBar.tsx
+++ b/packages/app/components/Nav/NavBar.tsx
@@ -239,7 +239,7 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
             />
           </LeftMenu>
           <RightMenu>
-            <ProfileDrawer courseId={courseId} />
+            <ProfileDrawer />
           </RightMenu>
           {/* FOR MOBILE ONLY:
           If on a queue, show the queue title,
@@ -291,7 +291,7 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
             tabs={tabs}
             hrefAsPath={asPath}
           />
-          <ProfileDrawer courseId={courseId} />
+          <ProfileDrawer />
         </Drawer>
       </Nav>
     </>
@@ -345,7 +345,7 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
             hrefAsPath={asPath}
             onClose={onClose}
           />
-          <ProfileDrawer courseId={null} />
+          <ProfileDrawer />
         </Drawer>
       </Nav>
     </>

--- a/packages/app/components/Nav/NavBar.tsx
+++ b/packages/app/components/Nav/NavBar.tsx
@@ -244,13 +244,16 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
           {/* FOR MOBILE ONLY:
           If on a queue, show the queue title,
            else only show the course name */}
-          <h1 className="inline-block sm:hidden">
-            {pathname.includes('queue')
-              ? course?.queues?.find(
-                  (queue) => queue.id === Number(asPath.split('/')[4]),
-                )?.room
-              : course?.name}
-          </h1>
+          <div className="inline-block flex flex-col items-center sm:hidden ">
+            <h1 className="leading-none">{course?.name}</h1>
+            <h2 className="text-base leading-none text-slate-500">
+              {pathname.includes('queue')
+                ? course?.queues?.find(
+                    (queue) => queue.id === Number(asPath.split('/')[4]),
+                  )?.room
+                : ''}
+            </h2>
+          </div>
         </MenuCon>
         {/* BarsMenu is the hamburger menu for mobile */}
         <BarsMenu type="primary" onClick={showDrawer}>

--- a/packages/app/components/Nav/NavBar.tsx
+++ b/packages/app/components/Nav/NavBar.tsx
@@ -267,7 +267,12 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
           onClose={onClose}
           bodyStyle={{ padding: '12px' }}
         >
-          <NavBarTabs currentHref={pathname} tabs={tabs} hrefAsPath={asPath} />
+          <NavBarTabs
+            onClose={onClose}
+            currentHref={pathname}
+            tabs={tabs}
+            hrefAsPath={asPath}
+          />
           <ProfileDrawer courseId={courseId} />
         </Drawer>
       </Nav>

--- a/packages/app/components/Nav/NavBar.tsx
+++ b/packages/app/components/Nav/NavBar.tsx
@@ -52,6 +52,12 @@ const MenuCon = styled.div`
   align-items: center;
   justify-content: space-between;
   padding-left: 0px;
+
+  // For centering the queue name or course name on mobile
+  @media (max-width: 650px) {
+    justify-content: center;
+    padding-right: 3em;
+  }
 `
 
 const LeftMenu = styled.div`
@@ -223,6 +229,7 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
           </a>
         )}
         <MenuCon>
+          {/* Left Menu (navbar tabs) and Right Menu (profile) only get shown on desktop  */}
           <LeftMenu>
             <NavBarTabs
               horizontal
@@ -234,7 +241,18 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
           <RightMenu>
             <ProfileDrawer courseId={courseId} />
           </RightMenu>
+          {/* FOR MOBILE ONLY:
+          If on a queue, show the queue title,
+           else only show the course name */}
+          <h1 className="inline-block sm:hidden">
+            {pathname.includes('queue')
+              ? course?.queues?.find(
+                  (queue) => queue.id === Number(asPath.split('/')[4]),
+                )?.room
+              : course?.name}
+          </h1>
         </MenuCon>
+        {/* BarsMenu is the hamburger menu for mobile */}
         <BarsMenu type="primary" onClick={showDrawer}>
           <BarsButton />
         </BarsMenu>

--- a/packages/app/components/Nav/NavBarTabs.tsx
+++ b/packages/app/components/Nav/NavBarTabs.tsx
@@ -4,31 +4,31 @@ import { Menu } from 'antd'
 import { MenuProps } from 'antd/lib/menu'
 import Link from 'next/link'
 import { QueuePartial } from '@koh/common'
-
-const { SubMenu } = Menu
+import './overwriteAntdNavStyes.css'
 
 const HorizontalMenu = styled(Menu)<MenuProps>`
   ${(props) => (props.mode === 'horizontal' ? 'border-bottom: none' : '')}
 `
 
+const { SubMenu } = Menu
 const QueueMenu = styled(SubMenu)`
   @media (min-width: 650px) {
     font-size: 16px !important;
     color: #262626 !important;
     margin: 0 !important;
     padding: 0 !important;
-  }
-  &&&:after {
-    left: 0px;
-    right: 0px;
-  }
-
-  &&& .ant-menu-submenu-title {
-    padding: 10px 50px !important;
+    &&& .ant-menu-submenu-title {
+      padding: 10px 50px !important;
+    }
+    &&&:after {
+      left: 0px;
+      right: 0px;
+    }
   }
 `
 
 const MenuItem = styled(Menu.Item)`
+  // desktop
   @media (min-width: 650px) {
     padding: 10px 50px !important;
     font-size: 16px !important;

--- a/packages/app/components/Nav/NavBarTabs.tsx
+++ b/packages/app/components/Nav/NavBarTabs.tsx
@@ -66,9 +66,14 @@ interface NavBarTabsProps {
   hrefAsPath: string
   tabs: NavBarTabsItem[]
   horizontal?: boolean
+  onClose?: () => void
 }
 
-function createQueueTab(queueTabItem: NavBarQueueTabItem, currentPath: string) {
+function createQueueTab(
+  queueTabItem: NavBarQueueTabItem,
+  currentPath: string,
+  onClose?: () => void,
+) {
   return (
     // need to manually add the ant-menu-item-selected class for this submenu and it's menu items since antd isn't adding it automatically like it should be
     <QueueMenu
@@ -89,6 +94,7 @@ function createQueueTab(queueTabItem: NavBarQueueTabItem, currentPath: string) {
             key={openQueue.id}
             data-cy={`queue-menu-item-${openQueue.room}`}
             className={isSelected ? 'ant-menu-item-selected' : ''}
+            onClick={onClose} // close the mobile drawer when clicked
           >
             <Link href="/course/[cid]/queue/[qid]" as={queuePath}>
               <a>{openQueue.room}</a>
@@ -115,6 +121,7 @@ export default function NavBarTabs({
   hrefAsPath,
   tabs,
   horizontal,
+  onClose,
 }: NavBarTabsProps): ReactElement {
   return (
     <HorizontalMenu
@@ -124,7 +131,7 @@ export default function NavBarTabs({
       {tabs.map((tab) =>
         tab.text !== 'Queue'
           ? createGeneralTab(tab as NavBarGeneralTabItem)
-          : createQueueTab(tab as NavBarQueueTabItem, hrefAsPath),
+          : createQueueTab(tab as NavBarQueueTabItem, hrefAsPath, onClose),
       )}
     </HorizontalMenu>
   )

--- a/packages/app/components/Nav/ProfileDrawer.tsx
+++ b/packages/app/components/Nav/ProfileDrawer.tsx
@@ -1,17 +1,9 @@
-import {
-  LogoutOutlined,
-  MacCommandOutlined,
-  QuestionCircleOutlined,
-  SettingOutlined,
-} from '@ant-design/icons'
-import { Menu, Modal, Popover, Typography, Space } from 'antd'
+import { LogoutOutlined, SettingOutlined } from '@ant-design/icons'
+import { Menu, Popover } from 'antd'
 import Link from 'next/link'
-import React, { ReactElement, ReactNode, useState } from 'react'
+import React, { ReactElement, useState } from 'react'
 import styled from 'styled-components'
 import SelfAvatar from '../common/SelfAvatar'
-import { useRoleInCourse } from '../../hooks/useRoleInCourse'
-import { Role } from '@koh/common'
-const { Text } = Typography
 
 const StyleablePopover = ({ className, ...props }: { className: string }) => (
   <Popover {...props} overlayClassName={className} />
@@ -19,6 +11,10 @@ const StyleablePopover = ({ className, ...props }: { className: string }) => (
 const NoPaddingPopover: typeof Popover = styled(StyleablePopover)`
   & .ant-popover-inner-content {
     padding: 0px;
+  }
+  // antd for some reason thinks having 24px of padding on the left and 16px of padding on the right looks good
+  .ant-menu-item {
+    padding: 0 16px !important;
   }
 `
 
@@ -32,82 +28,18 @@ const AvatarButton = styled.div`
   }
 `
 
-interface ProfileDrawerProps {
-  courseId: number
-}
-
-function shortcutInfoContent(role: Role): ReactNode {
-  if (role === Role.STUDENT) {
-    return (
-      <Space direction="vertical" style={{ display: 'flex' }}>
-        <Space>
-          <Text keyboard>shift</Text>
-          <Text keyboard>n</Text>Create a new question
-        </Space>
-        <Space>
-          <Text keyboard>shift</Text>
-          <Text keyboard>e</Text>Edit question
-        </Space>
-        <Space size={40}>
-          <Text keyboard>enter</Text>Finish writing question
-        </Space>
-      </Space>
-    )
-  } else {
-    return (
-      <Space direction="vertical" style={{ display: 'flex' }}>
-        <Space>
-          <Text keyboard>shift</Text>
-          <Text keyboard>h</Text>Help the next student
-        </Space>
-        <Space>
-          <Text keyboard>shift</Text>
-          <Text keyboard>d</Text>Delete the currently selected student&apos;s
-          question
-        </Space>
-        <Space>
-          <Space size={1}>
-            <Text keyboard>up</Text>/<Text keyboard>down</Text>
-          </Space>
-          Navigate through students
-        </Space>
-      </Space>
-    )
-  }
-}
-
-export default function ProfileDrawer({
-  courseId = null,
-}: ProfileDrawerProps): ReactElement {
+export default function ProfileDrawer(): ReactElement {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
-  const role = useRoleInCourse(courseId)
   return (
     <>
       <NoPaddingPopover
         content={
           <Menu mode="inline">
             <Menu.Item icon={<SettingOutlined />}>
-              <Link href={{ pathname: '/settings' }}>
-                <a>Settings</a>
-              </Link>
-            </Menu.Item>
-            <Menu.Item
-              hidden={courseId === null}
-              icon={<MacCommandOutlined />}
-              onClick={() => {
-                Modal.info({
-                  title: 'Queue Page Keyboard Shortcuts',
-                  content: shortcutInfoContent(role),
-                })
-                setIsPopoverOpen(false)
-              }}
-            >
-              Keyboard Shortcuts
+              <Link href={{ pathname: '/settings' }}>Settings</Link>
             </Menu.Item>
             <Menu.Item key="2" icon={<LogoutOutlined />}>
-              <Link href={'/api/v1/logout'}>
-                <a data-cy="logout-button">Logout</a>
-              </Link>
+              <Link href={'/api/v1/logout'}>Logout</Link>
             </Menu.Item>
           </Menu>
         }

--- a/packages/app/components/Nav/ProfileDrawer.tsx
+++ b/packages/app/components/Nav/ProfileDrawer.tsx
@@ -24,6 +24,12 @@ const NoPaddingPopover: typeof Popover = styled(StyleablePopover)`
 
 const AvatarButton = styled.div`
   cursor: pointer;
+
+  // give it a bit of margins in the mobile navbar drawer
+  @media (max-width: 650px) {
+    margin-left: 1em;
+    margin-top: 1em;
+  }
 `
 
 interface ProfileDrawerProps {
@@ -111,7 +117,9 @@ export default function ProfileDrawer({
         onOpenChange={setIsPopoverOpen}
       >
         <AvatarButton>
-          <SelfAvatar size={40} />
+          {/* show a larger avatar icon for mobile */}
+          <SelfAvatar className="hidden sm:inline-block" size={40} />
+          <SelfAvatar className="inline-block sm:hidden" size={50} />
         </AvatarButton>
       </NoPaddingPopover>
     </>

--- a/packages/app/components/Nav/ProfileDrawer.tsx
+++ b/packages/app/components/Nav/ProfileDrawer.tsx
@@ -105,7 +105,7 @@ export default function ProfileDrawer({
             </Menu.Item>
           </Menu>
         }
-        placement="bottomRight"
+        placement="bottomLeft"
         trigger="click"
         open={isPopoverOpen}
         onOpenChange={setIsPopoverOpen}

--- a/packages/app/components/Nav/overwriteAntdNavStyes.css
+++ b/packages/app/components/Nav/overwriteAntdNavStyes.css
@@ -1,7 +1,7 @@
 
 
 /* Overwrite antd Nav styles to specifically move the navbar over to the right */
-.ant-menu-submenu {
+.ant-menu-submenu.ant-menu-submenu-popup.ant-menu {
     @media (max-width: 650px) {
         left: 50vw !important;
     }

--- a/packages/app/components/Nav/overwriteAntdNavStyes.css
+++ b/packages/app/components/Nav/overwriteAntdNavStyes.css
@@ -1,0 +1,8 @@
+
+
+/* Overwrite antd Nav styles to specifically move the navbar over to the right */
+.ant-menu-submenu {
+    @media (max-width: 650px) {
+        left: 50vw !important;
+    }
+}

--- a/packages/app/components/Queue/Banner.tsx
+++ b/packages/app/components/Queue/Banner.tsx
@@ -4,6 +4,9 @@ import styled from 'styled-components'
 
 const BannerContainer = styled.div`
   width: 100%;
+  @media (max-width: 650px) {
+    margin-bottom: 1em;
+  }
 `
 
 const TitleContainer = styled.div`

--- a/packages/app/components/Queue/Banner.tsx
+++ b/packages/app/components/Queue/Banner.tsx
@@ -71,9 +71,14 @@ export const BannerButton = styled(Button).attrs({
   size: 'large',
   shape: 'circle',
 })`
-  margin-left: 16px;
+  margin-left: 0.75rem;
   border: 0;
   background: #fff;
+
+  @media (max-width: 650px) {
+    margin-left: 0.5rem;
+    margin-top: 0.35rem;
+  }
 `
 
 export const BannerPrimaryButton = styled(BannerButton)`

--- a/packages/app/components/Queue/Banner.tsx
+++ b/packages/app/components/Queue/Banner.tsx
@@ -1,13 +1,13 @@
-import { Button } from "antd";
-import { ReactElement, ReactNode } from "react";
-import styled from "styled-components";
+import { Button } from 'antd'
+import { ReactElement, ReactNode } from 'react'
+import styled from 'styled-components'
 
 const BannerContainer = styled.div`
   width: 100%;
-`;
+`
 
 const TitleContainer = styled.div`
-  background: ${({ color }) => color || "#8895A6"};
+  background: ${({ color }) => color || '#8895A6'};
   padding-left: 24px;
   padding-right: 16px;
   min-height: 60px;
@@ -18,35 +18,32 @@ const TitleContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-`;
+`
 const Title = styled.div`
   font-weight: 300;
   font-size: 24px;
   color: white;
-`;
+`
 const ButtonContainer = styled.div`
   display: flex;
   flex-flow: row wrap;
   margin-right: 10px;
-`;
+`
 
 const ContentContainer = styled.div`
-  background: ${({ color }) => color || "#CFD6DE"};
+  background: ${({ color }) => color || '#CFD6DE'};
   padding: 12px 24px;
   border-radius: 0 0 6px 6px;
-`;
+`
 
 interface BannerProps {
-  title?: string | ReactNode;
-  content?: string | ReactNode;
-  titleColor?: string;
-  contentColor?: string;
-  buttons?: ReactNode;
+  title?: string | ReactNode
+  content?: string | ReactNode
+  titleColor?: string
+  contentColor?: string
+  buttons?: ReactNode
 }
 
-interface CircleButtonProps {
-  [x: string]: any;
-}
 /**
  * Presentation-only component
  */
@@ -61,24 +58,23 @@ export default function Banner(props: BannerProps): ReactElement {
         {props.content}
       </ContentContainer>
     </BannerContainer>
-  );
-}
-
-export function CircleButton({ ...props }: CircleButtonProps): ReactElement {
-  return <Button size="large" shape="circle" {...props} />;
+  )
 }
 
 /**
  * Buttons to be used in the banner
  */
-export const BannerButton = styled(CircleButton)`
+export const BannerButton = styled(Button).attrs({
+  size: 'large',
+  shape: 'circle',
+})`
   margin-left: 16px;
   border: 0;
   background: #fff;
-`;
+`
 
 export const BannerPrimaryButton = styled(BannerButton)`
-  ${({ disabled }) => disabled && "pointer-events: none"};
+  ${({ disabled }) => disabled && 'pointer-events: none'};
   background: #3684c6;
   color: #fff;
   &:hover,
@@ -86,10 +82,10 @@ export const BannerPrimaryButton = styled(BannerButton)`
     background: #3c93dd;
     color: #fff;
   }
-`;
+`
 
 export const BannerDangerButton = styled(BannerButton)`
-  ${({ disabled }) => disabled && "pointer-events: none"};
+  ${({ disabled }) => disabled && 'pointer-events: none'};
   background: #e26567;
   color: #fff;
   &:hover,
@@ -97,10 +93,10 @@ export const BannerDangerButton = styled(BannerButton)`
     background: #fc7f81;
     color: #fff;
   }
-`;
+`
 
 export const BannerOrangeButton = styled(BannerButton)`
-  ${({ disabled }) => disabled && "pointer-events: none"};
+  ${({ disabled }) => disabled && 'pointer-events: none'};
   background: #ff8c00;
   color: #fff;
   &:hover,
@@ -108,7 +104,7 @@ export const BannerOrangeButton = styled(BannerButton)`
     background: #ffa700;
     color: #fff;
   }
-`;
+`
 
 export const FinishHelpingButton = styled(BannerButton)`
   border: 0;
@@ -119,7 +115,7 @@ export const FinishHelpingButton = styled(BannerButton)`
     background: #82c985;
     color: #fff;
   }
-`;
+`
 
 export const CantFindButton = styled(BannerButton)`
   background: #fff;
@@ -130,7 +126,7 @@ export const CantFindButton = styled(BannerButton)`
     background: #fc7f81;
     color: #fff;
   }
-`;
+`
 
 export const RequeueButton = styled(BannerButton)`
   background: #ffffff;
@@ -141,4 +137,4 @@ export const RequeueButton = styled(BannerButton)`
     background: #f0f0f0;
     color: #000000;
   }
-`;
+`

--- a/packages/app/components/Queue/Banner.tsx
+++ b/packages/app/components/Queue/Banner.tsx
@@ -26,7 +26,7 @@ const Title = styled.div`
 `
 const ButtonContainer = styled.div`
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: row nowrap;
   margin-right: 10px;
 `
 

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -246,6 +246,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
   }, [qid])
 
   const closeEditModal = useCallback(() => {
+    console.log('closeEditModal')
     setPopupEditQuestion(false)
     setIsJoining(false)
   }, [])
@@ -430,7 +431,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
     font-weight: 500;
     font-size: 24px;
     color: #212934;
-    margin-bottom: 0;
+    margin-bottom: 0.25em;
   `
 
   const NoQuestionsText = styled.div`
@@ -450,7 +451,6 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
         ) : (
           <>
             <QueueHeader>Queue</QueueHeader>
-            <br></br>
             {/* <StudentHeaderCard bordered={false}>
               <CenterRow>
                 <Col flex="1 1">
@@ -511,7 +511,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
                 editQuestion={openEditModal}
                 leaveQueue={leaveQueue}
               />
-              <div style={{ marginTop: '40px' }} />
+              <div className="mt-4" />
             </>
           )}
           <RenderQueueQuestions questions={questions?.queue} />

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -36,16 +36,6 @@ import { AddStudentsModal } from './TA/TAAddStudent'
 import { EditQueueModal } from './TA/EditQueueModal'
 import PropTypes from 'prop-types'
 
-const HelpNextButton = styled(QueueInfoColumnButton)`
-  color: white;
-  background: #2a9187;
-  &:hover,
-  &:focus {
-    color: white;
-    background: #39aca1;
-  }
-`
-
 const EditQueueButton = styled(QueueInfoColumnButton)`
   color: #212934;
 `
@@ -235,11 +225,6 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
     [mutateQuestions, qid, questions],
   )
 
-  const helpNext = async () => {
-    await onHelpQuestion(nextQuestion.id)
-    mutateQuestions()
-  }
-
   const openEditModal = useCallback(async () => {
     mutate(`/api/v1/queues/${qid}/questions`)
     setPopupEditQuestion(true)
@@ -355,17 +340,6 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
             >
               Add Students
             </EditQueueButton>
-            <Tooltip
-              title={!isCheckedIn && 'You must check in to help students!'}
-            >
-              <HelpNextButton
-                onClick={helpNext}
-                disabled={!isCheckedIn || !nextQuestion || isHelping}
-                data-cy="help-next"
-              >
-                Help Next
-              </HelpNextButton>
-            </Tooltip>
 
             <div className="my-3">
               <Tooltip

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -447,6 +447,8 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
           </>
         )}
         {questions?.map((question: Question, index: number) => {
+          const background_color =
+            question.id === studentQuestionId ? 'bg-teal-200/25' : 'bg-white'
           return (
             <StudentQueueCard
               key={question.id}
@@ -455,6 +457,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
               cid={cid}
               qid={qid}
               isStaff={isStaff}
+              className={background_color}
             />
           )
         })}

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -35,7 +35,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage'
 import { AddStudentsModal } from './TA/TAAddStudent'
 import { EditQueueModal } from './TA/EditQueueModal'
 import PropTypes from 'prop-types'
-import { LoginOutlined } from '@ant-design/icons'
+import { EditOutlined, LoginOutlined, PlusOutlined } from '@ant-design/icons'
 
 const EditQueueButton = styled(QueueInfoColumnButton)`
   color: #212934;
@@ -349,6 +349,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
             <EditQueueButton
               data-cy="editQueue"
               onClick={() => setQueueSettingsModal(true)}
+              icon={<EditOutlined />}
             >
               {/* only show the "Details" part on desktop to keep button small on mobile */}
               <span>
@@ -359,8 +360,13 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
               data-cy="addStudents"
               disabled={!isCheckedIn}
               onClick={() => setAddStudentsModal(true)}
+              icon={<PlusOutlined />}
             >
-              Add Students
+              {/* "+ Add Students to Queue" on desktop, "+ Students" on mobile */}
+              <span>
+                <span className="hidden sm:inline">Add</span> Students{' '}
+                <span className="hidden sm:inline">to Queue</span>
+              </span>
             </EditQueueButton>
           </>
         }

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -72,6 +72,10 @@ const QueueListContainer = styled.div`
 const JoinButton = styled(QueueInfoColumnButton)`
   background-color: #3684c6;
   color: white;
+
+  @media (max-width: 650px) {
+    margin: 0;
+  }
 `
 
 const VerticalDivider = styled.div`
@@ -450,7 +454,8 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
           <NoQuestionsText>There are no questions in the queue</NoQuestionsText>
         ) : (
           <>
-            <QueueHeader>Queue</QueueHeader>
+            {/* only show this queue header on desktop */}
+            <QueueHeader className="hidden sm:block">Queue</QueueHeader>
             {/* <StudentHeaderCard bordered={false}>
               <CenterRow>
                 <Col flex="1 1">
@@ -501,8 +506,6 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
                   />
                 )
               })}
-              <br></br>
-              <br></br>
             </>
           ) : (
             <>
@@ -511,7 +514,6 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
                 editQuestion={openEditModal}
                 leaveQueue={leaveQueue}
               />
-              <div className="mt-4" />
             </>
           )}
           <RenderQueueQuestions questions={questions?.queue} />

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -35,7 +35,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage'
 import { AddStudentsModal } from './TA/TAAddStudent'
 import { EditQueueModal } from './TA/EditQueueModal'
 import PropTypes from 'prop-types'
-import { LoginOutlined, PlusOutlined } from '@ant-design/icons'
+import { LoginOutlined } from '@ant-design/icons'
 
 const EditQueueButton = styled(QueueInfoColumnButton)`
   color: #212934;

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -340,17 +340,16 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
                   queue.isDisabled
                 }
                 state={isCheckedIn ? 'CheckedIn' : 'CheckedOut'}
+                className="w-1/3 sm:w-full"
               />
             </Tooltip>
             <EditQueueButton
               data-cy="editQueue"
               onClick={() => setQueueSettingsModal(true)}
             >
+              {/* only show the "Details" part on desktop to keep button small on mobile */}
               <span>
-                {' '}
-                Edit Queue <span className="hidden sm:inline">
-                  Details
-                </span>{' '}
+                Edit Queue <span className="hidden sm:inline">Details</span>
               </span>
             </EditQueueButton>
             <EditQueueButton

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -72,10 +72,6 @@ const QueueListContainer = styled.div`
 const JoinButton = styled(QueueInfoColumnButton)`
   background-color: #3684c6;
   color: white;
-
-  @media (max-width: 650px) {
-    margin: 0;
-  }
 `
 
 const VerticalDivider = styled.div`
@@ -371,7 +367,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
               </HelpNextButton>
             </Tooltip>
 
-            <div style={{ marginBottom: '12px' }}>
+            <div className="my-3">
               <Tooltip
                 title={
                   queue.isDisabled && 'Cannot check into a disabled queue!'
@@ -387,7 +383,6 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
                     queue.isDisabled
                   }
                   state={isCheckedIn ? 'CheckedIn' : 'CheckedOut'}
-                  block
                 />
               </Tooltip>
             </div>

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -35,6 +35,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage'
 import { AddStudentsModal } from './TA/TAAddStudent'
 import { EditQueueModal } from './TA/EditQueueModal'
 import PropTypes from 'prop-types'
+import { PlusOutlined } from '@ant-design/icons'
 
 const EditQueueButton = styled(QueueInfoColumnButton)`
   color: #212934;
@@ -62,6 +63,8 @@ const QueueListContainer = styled.div`
 const JoinButton = styled(QueueInfoColumnButton)`
   background-color: #3684c6;
   color: white;
+  align-items: center;
+  display: flex;
 `
 
 const VerticalDivider = styled.div`
@@ -390,6 +393,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
                 onClick={async () =>
                   setShowJoinPopconfirm(!(await joinQueueOpenModal(false)))
                 }
+                icon={<PlusOutlined />}
               >
                 Join Queue
               </JoinButton>

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -35,7 +35,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage'
 import { AddStudentsModal } from './TA/TAAddStudent'
 import { EditQueueModal } from './TA/EditQueueModal'
 import PropTypes from 'prop-types'
-import { PlusOutlined } from '@ant-design/icons'
+import { LoginOutlined, PlusOutlined } from '@ant-design/icons'
 
 const EditQueueButton = styled(QueueInfoColumnButton)`
   color: #212934;
@@ -393,7 +393,7 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
                 onClick={async () =>
                   setShowJoinPopconfirm(!(await joinQueueOpenModal(false)))
                 }
-                icon={<PlusOutlined />}
+                icon={<LoginOutlined />}
               >
                 Join Queue
               </JoinButton>

--- a/packages/app/components/Queue/Queue.tsx
+++ b/packages/app/components/Queue/Queue.tsx
@@ -327,11 +327,31 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
         isStaff={true}
         buttons={
           <>
+            <Tooltip
+              title={queue.isDisabled && 'Cannot check into a disabled queue!'}
+            >
+              <TACheckinButton
+                courseId={cid}
+                room={queue?.room}
+                disabled={
+                  staffCheckedIntoAnotherQueue ||
+                  isHelping ||
+                  (queue.isProfessorQueue && role !== Role.PROFESSOR) ||
+                  queue.isDisabled
+                }
+                state={isCheckedIn ? 'CheckedIn' : 'CheckedOut'}
+              />
+            </Tooltip>
             <EditQueueButton
               data-cy="editQueue"
               onClick={() => setQueueSettingsModal(true)}
             >
-              Edit Queue Details
+              <span>
+                {' '}
+                Edit Queue <span className="hidden sm:inline">
+                  Details
+                </span>{' '}
+              </span>
             </EditQueueButton>
             <EditQueueButton
               data-cy="addStudents"
@@ -340,26 +360,6 @@ export default function QueuePage({ qid, cid }: QueuePageProps): ReactElement {
             >
               Add Students
             </EditQueueButton>
-
-            <div className="my-3">
-              <Tooltip
-                title={
-                  queue.isDisabled && 'Cannot check into a disabled queue!'
-                }
-              >
-                <TACheckinButton
-                  courseId={cid}
-                  room={queue?.room}
-                  disabled={
-                    staffCheckedIntoAnotherQueue ||
-                    isHelping ||
-                    (queue.isProfessorQueue && role !== Role.PROFESSOR) ||
-                    queue.isDisabled
-                  }
-                  state={isCheckedIn ? 'CheckedIn' : 'CheckedOut'}
-                />
-              </Tooltip>
-            </div>
           </>
         }
       />

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -30,6 +30,7 @@ const QueueTitle = styled.h2`
   color: #212934;
   margin-bottom: 0px;
   line-height: 2rem;
+  display: inline-block;
 `
 
 export const NotesText = styled.div`
@@ -58,12 +59,19 @@ const QueueInfoColumnButtonStyle = styled(Button)`
   border: 1px solid #cfd6de;
   border-radius: 6px;
   margin-bottom: 12px;
+  width: 100%;
+
+  // less margin and width on mobile
+  @media (max-width: 650px) {
+    margin-bottom: 0;
+    width: 30%;
+  }
 `
 
 const { confirm } = Modal
 
 export const QueueInfoColumnButton = (props: ButtonProps): ReactElement => (
-  <QueueInfoColumnButtonStyle size="large" block {...props} />
+  <QueueInfoColumnButtonStyle size="large" {...props} />
 )
 
 const QueuePropertyRow = styled.div`
@@ -156,6 +164,11 @@ const QueueManagementBox = styled.div`
   width: 100%;
   height: 100%;
   bottom: 0;
+
+  @media (max-width: 650px) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 `
 
 interface QueueInfoColumnProps {
@@ -205,7 +218,12 @@ export function QueueInfoColumn({
   // };
   return (
     <InfoColumnContainer>
-      <QueueInfo>
+      {/* only show the queue title and warning here on desktop, move down on mobile */}
+      <QueueInfo className="justify-left hidden items-center sm:flex">
+        <QueueTitle data-cy="room-title">
+          {queue?.room} {queue?.isDisabled && <b>(disabled)</b>}
+        </QueueTitle>
+
         <QueueRoomGroup>
           {!queue.allowQuestions && (
             <Tooltip title="This queue is no longer accepting questions">
@@ -216,10 +234,6 @@ export function QueueInfoColumn({
             </Tooltip>
           )}
         </QueueRoomGroup>
-
-        <QueueTitle className="hidden sm:inline-block" data-cy="room-title">
-          {queue?.room} {queue?.isDisabled && <b>(disabled)</b>}
-        </QueueTitle>
       </QueueInfo>
 
       {queue?.notes && (
@@ -263,7 +277,11 @@ export function QueueInfoColumn({
       )}
 
       {/* buttons for staff on mobile */}
-      {isStaff && <div className="block sm:hidden">{buttons}</div>}
+      {isStaff && (
+        <div className="mt-3 block flex flex-wrap items-center justify-between sm:hidden">
+          {buttons}
+        </div>
+      )}
 
       {isStaff && (
         <QueueManagementBox>
@@ -303,11 +321,7 @@ export function QueueInfoColumn({
           <QueueUpToDateInfo queueId={queueId} />
         </div>
         {/* for 'Join Queue' button for students */}
-        {!isStaff && (
-          <div className="block flex w-1/3 items-center justify-between sm:hidden">
-            {buttons}
-          </div>
-        )}
+        {!isStaff && buttons}
       </div>
     </InfoColumnContainer>
   )

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -81,10 +81,20 @@ const QueuePropertyText = styled.div`
 
   // to show new lines in the text
   white-space: pre-wrap;
+
+  /* make text smaller on mobile */
+  @media (max-width: 650px) {
+    font-size: 14px;
+  }
 `
 
 const StaffH2 = styled.h2`
   margin-top: 32px;
+
+  // less margin on mobile
+  @media (max-width: 650px) {
+    margin-top: 16px;
+  }
 `
 
 const QueueRoomGroup = styled.div`
@@ -95,6 +105,11 @@ const QueueRoomGroup = styled.div`
 
 const QueueInfo = styled.div`
   margin-bottom: 24px;
+
+  // less margin on mobile
+  @media (max-width: 650px) {
+    margin-bottom: 0px;
+  }
 `
 
 const QueueText = styled.div`

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -210,16 +210,9 @@ export function QueueInfoColumn({
           )}
         </QueueRoomGroup>
 
-        {queue.staffList.length < 1 ? (
-          <h1>
-            No staff checked in, wait for a staff member to check in to post
-            questions
-          </h1>
-        ) : (
-          <QueueTitle data-cy="room-title">
-            {queue?.room} {queue?.isDisabled && <b>(disabled)</b>}
-          </QueueTitle>
-        )}
+        <QueueTitle data-cy="room-title">
+          {queue?.room} {queue?.isDisabled && <b>(disabled)</b>}
+        </QueueTitle>
       </QueueInfo>
       {queue?.notes && (
         <QueuePropertyRow>
@@ -243,9 +236,21 @@ export function QueueInfoColumn({
         </QueuePropertyRow>
       )}
       <QueueUpToDateInfo queueId={queueId} />
+
       {buttons}
+
       <StaffH2>Staff</StaffH2>
-      <TAStatuses queueId={queueId} />
+      {queue.staffList.length < 1 ? (
+        <div
+          role="alert"
+          className="border-l-4 border-orange-500 bg-orange-100 p-4 text-orange-700"
+        >
+          <p> No staff checked in</p>
+        </div>
+      ) : (
+        <TAStatuses queueId={queueId} />
+      )}
+
       {isStaff && (
         <QueueManagementBox>
           {/* <p>Toggle to indicate away </p>

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -278,7 +278,7 @@ export function QueueInfoColumn({
 
       {/* buttons for staff on mobile */}
       {isStaff && (
-        <div className="mt-3 block flex flex-wrap items-center justify-between sm:hidden">
+        <div className="my-3 block flex flex-wrap items-center justify-between sm:hidden">
           {buttons}
         </div>
       )}

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -60,6 +60,9 @@ const QueueInfoColumnButtonStyle = styled(Button)`
   border-radius: 6px;
   margin-bottom: 12px;
   width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   // less margin and width on mobile
   @media (max-width: 650px) {

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -137,7 +137,7 @@ const QueueText = styled.div`
   width: 100%;
 `
 
-const DisableQueueButton = styled(QueueInfoColumnButton)`
+export const DisableQueueButton = styled(QueueInfoColumnButton)`
   color: white;
   background: #da3236;
   &:hover,
@@ -148,7 +148,7 @@ const DisableQueueButton = styled(QueueInfoColumnButton)`
   }
 `
 
-const ClearQueueButton = styled(QueueInfoColumnButton)`
+export const ClearQueueButton = styled(QueueInfoColumnButton)`
   color: #d4380d;
   background: #fff;
   border-color: #d4380d;
@@ -168,11 +168,6 @@ const QueueManagementBox = styled.div`
   width: 100%;
   height: 100%;
   bottom: 0;
-
-  @media (max-width: 650px) {
-    flex-direction: row;
-    justify-content: space-between;
-  }
 `
 
 interface QueueInfoColumnProps {
@@ -188,31 +183,6 @@ export function QueueInfoColumn({
 }: QueueInfoColumnProps): ReactElement {
   const { queue, mutateQueue } = useQueue(queueId)
   // const [away, setAway] = useState(false);
-  const disableQueue = async () => {
-    await API.queues.disable(queueId)
-    await mutateQueue()
-    message.success('Successfully disabled queue: ' + queue.room)
-    await Router.push('/')
-  }
-
-  const clearQueue = async () => {
-    await API.queues.clean(queueId)
-    await mutateQueue()
-    message.success('Successfully cleaned queue: ' + queue.room)
-  }
-
-  const confirmDisable = () => {
-    confirm({
-      title: `Please Confirm!`,
-      icon: <ExclamationCircleOutlined />,
-      style: { whiteSpace: 'pre-wrap' },
-      content: `Please confirm that you want to disable the queue: ${queue.room}.\n
-      This queue will no longer appear in the app, and any students currently in the queue will be removed.`,
-      onOk() {
-        disableQueue()
-      },
-    })
-  }
   // const checkAway = (checked: boolean) => {
   //   if (!checked) {
   //     setAway(true);
@@ -288,7 +258,8 @@ export function QueueInfoColumn({
       )}
 
       {isStaff && (
-        <QueueManagementBox>
+        // "Clear Queue" and "Delete Queue" buttons for DESKTOP ONLY - mobile is in EditQueueModal.tsx
+        <QueueManagementBox className="!hidden sm:!flex">
           {/* <p>Toggle to indicate away </p>
           <Switch
             onChange={checkAway}
@@ -304,12 +275,16 @@ export function QueueInfoColumn({
             cancelText="No"
             placement="top"
             arrowPointAtCenter={true}
-            onConfirm={clearQueue}
+            onConfirm={() => clearQueue(queueId, queue)}
           >
-            <ClearQueueButton>Clear Queue</ClearQueueButton>
+            {/* Hide button on mobile (it gets moved to edit queue modal) */}
+            <ClearQueueButton className="hidden sm:flex">
+              Clear Queue
+            </ClearQueueButton>
           </Popconfirm>
+          {/* Hide button on mobile (it gets moved to edit queue modal) */}
           <DisableQueueButton
-            onClick={confirmDisable}
+            onClick={() => confirmDisable(queueId, queue)}
             data-cy="queue-disable-button"
             disabled={queue?.isDisabled}
           >
@@ -358,6 +333,33 @@ function QueueUpToDateInfo({ queueId }: { queueId: number }): ReactElement {
       </QueuePropertyText>
     </QueuePropertyRow>
   )
+}
+
+export const clearQueue = async (queueId: number, queue: { room: string }) => {
+  await API.queues.clean(queueId)
+  message.success('Successfully cleaned queue: ' + queue.room)
+}
+
+export const confirmDisable = (queueId: number, queue: { room: string }) => {
+  confirm({
+    title: `Please Confirm!`,
+    icon: <ExclamationCircleOutlined />,
+    style: { whiteSpace: 'pre-wrap' },
+    content: `Please confirm that you want to disable the queue: ${queue.room}.\n
+    This queue will no longer appear in the app, and any students currently in the queue will be removed.`,
+    onOk() {
+      disableQueue(queueId, queue)
+    },
+  })
+}
+
+export const disableQueue = async (
+  queueId: number,
+  queue: { room: string },
+) => {
+  await API.queues.disable(queueId)
+  message.success('Successfully disabled queue: ' + queue.room)
+  await Router.push('/')
 }
 
 interface QuestionTypeProps {

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -24,10 +24,12 @@ export const Container = styled.div`
   align-items: center;
 `
 
-const QueueTitle = styled.div`
-  font-weight: 500;
-  font-size: 24px;
+const QueueTitle = styled.h2`
+  font-weight: 700;
+  font-size: 1.5rem;
   color: #212934;
+  margin-bottom: 0px;
+  line-height: 2rem;
 `
 
 export const NotesText = styled.div`
@@ -38,13 +40,15 @@ export const NotesText = styled.div`
 // New queue styled components start here
 const InfoColumnContainer = styled.div`
   flex-shrink: 0;
-  padding-bottom: 30px;
   position: relative;
   display: flex;
   flex-direction: column;
+  padding-bottom: 0.75em;
+
   @media (min-width: 650px) {
     margin-top: 32px;
     width: 290px;
+    padding-bottom: 30px;
   }
 `
 
@@ -69,6 +73,11 @@ const QueuePropertyRow = styled.div`
   margin-bottom: 20px;
   color: #5f6b79;
   font-size: 20px;
+
+  // less margin on mobile
+  @media (max-width: 650px) {
+    margin-bottom: 0;
+  }
 `
 
 const QueuePropertyText = styled.div`
@@ -88,13 +97,11 @@ const QueuePropertyText = styled.div`
   }
 `
 
-const StaffH2 = styled.h2`
-  margin-top: 32px;
-
-  // less margin on mobile
-  @media (max-width: 650px) {
-    margin-top: 16px;
-  }
+const CustomH3 = styled.h3`
+  margin-bottom: 0;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 600;
 `
 
 const QueueRoomGroup = styled.div`
@@ -104,7 +111,7 @@ const QueueRoomGroup = styled.div`
 `
 
 const QueueInfo = styled.div`
-  margin-bottom: 24px;
+  margin-bottom: 8px;
 
   // less margin on mobile
   @media (max-width: 650px) {
@@ -210,10 +217,11 @@ export function QueueInfoColumn({
           )}
         </QueueRoomGroup>
 
-        <QueueTitle data-cy="room-title">
+        <QueueTitle className="hidden sm:inline-block" data-cy="room-title">
           {queue?.room} {queue?.isDisabled && <b>(disabled)</b>}
         </QueueTitle>
       </QueueInfo>
+
       {queue?.notes && (
         <QueuePropertyRow>
           <NotificationOutlined />
@@ -235,11 +243,14 @@ export function QueueInfoColumn({
           </QueueText>
         </QueuePropertyRow>
       )}
-      <QueueUpToDateInfo queueId={queueId} />
 
-      {buttons}
+      {/* buttons and queueUpToDateInfo for desktop (has different order than mobile)*/}
+      <div className="hidden sm:block">
+        <QueueUpToDateInfo queueId={queueId} />
+        {buttons}
+      </div>
 
-      <StaffH2>Staff</StaffH2>
+      <CustomH3 className="mt-0 sm:mt-10">Staff</CustomH3>
       {queue.staffList.length < 1 ? (
         <div
           role="alert"
@@ -250,6 +261,9 @@ export function QueueInfoColumn({
       ) : (
         <TAStatuses queueId={queueId} />
       )}
+
+      {/* buttons for staff on mobile */}
+      {isStaff && <div className="block sm:hidden">{buttons}</div>}
 
       {isStaff && (
         <QueueManagementBox>
@@ -281,6 +295,20 @@ export function QueueInfoColumn({
           </DisableQueueButton>
         </QueueManagementBox>
       )}
+
+      {/* mobile only */}
+      <div className="mt-3 block flex items-center justify-between sm:hidden">
+        <div className="flex flex-col">
+          <CustomH3 className="mt-0">Queue</CustomH3>
+          <QueueUpToDateInfo queueId={queueId} />
+        </div>
+        {/* for 'Join Queue' button for students */}
+        {!isStaff && (
+          <div className="block flex w-1/3 items-center justify-between sm:hidden">
+            {buttons}
+          </div>
+        )}
+      </div>
     </InfoColumnContainer>
   )
 }

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -91,6 +91,7 @@ const QueuePropertyRow = styled.div`
 const QueuePropertyText = styled.div`
   margin-left: 12px;
   font-size: 16px;
+  font-style: italic;
 
   // To break text in flexbox
   min-width: 0;

--- a/packages/app/components/Queue/Student/StudentQueueCard.tsx
+++ b/packages/app/components/Queue/Student/StudentQueueCard.tsx
@@ -4,7 +4,6 @@ import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { getWaitTime } from '../../../utils/TimeUtil'
 import { CenterRow, Text } from '../QueueCardSharedComponents'
-import { truncate } from '../QueueUtils'
 import TAQueueDetailButtons from '../TA/TAQueueDetailButtons'
 import { QuestionType } from '../QueueListSharedComponents'
 import { KOHAvatar } from '../../common/SelfAvatar'
@@ -13,7 +12,6 @@ import HotnessBar from './HotnessBar'
 const HorizontalStudentCard = styled(Card)`
   margin-bottom: 8px;
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
-  background: #ffffff;
   border-radius: 6px;
   padding-left: 8px;
   padding-right: 8px;
@@ -33,6 +31,7 @@ interface StudentQueueCardProps {
   cid: number
   qid: number
   isStaff: boolean
+  className?: string // used to highlight questions or add other classes
 }
 
 export default function StudentQueueCard({
@@ -40,9 +39,10 @@ export default function StudentQueueCard({
   cid,
   qid,
   isStaff,
+  className,
 }: StudentQueueCardProps): ReactElement {
   return (
-    <HorizontalStudentCard>
+    <HorizontalStudentCard className={className}>
       <CenterRow>
         {/* Temporary removal of hotness bar
         <Col flex="0 1 auto" style={{ margin: '0 6px 0 0' }}>

--- a/packages/app/components/Queue/Student/StudentQueueCard.tsx
+++ b/packages/app/components/Queue/Student/StudentQueueCard.tsx
@@ -20,6 +20,10 @@ const HorizontalStudentCard = styled(Card)`
   color: #595959;
   .ant-card-body {
     padding: 10px 8px;
+
+    @media (max-width: 650px) {
+      padding: 10px 0px;
+    }
   }
 `
 
@@ -45,7 +49,7 @@ export default function StudentQueueCard({
           <HotnessBar hotness={Math.floor(Math.random() * 101)} />
         </Col> */}
         {isStaff && ( // only show avatar if staff for now. TODO: fix endpoint to allow queues to access student avatars and names if prof enabled it
-          <Col flex="0 1 auto" style={{ margin: '0 12px 0 0' }}>
+          <Col flex="0 1 auto" className="mr-2">
             <KOHAvatar
               size={46}
               name={question.creator.name}
@@ -54,7 +58,7 @@ export default function StudentQueueCard({
           </Col>
         )}
         <Col flex="1 1">
-          <Tooltip // only show tooltip if text is too long
+          <Tooltip // only show tooltip if text is too long TODO: replace with expand card details feature
             title={question.text.length > 110 ? question.text : ''}
             overlayStyle={{ maxWidth: '60em' }}
           >
@@ -105,12 +109,13 @@ export default function StudentQueueCard({
           <Text>{getWaitTime(question)}</Text>
         </Col>
         {isStaff && (
-          <Col>
+          <Col className="w-full sm:w-auto">
             <TAQueueDetailButtons
               courseId={cid}
               queueId={qid}
               question={question}
               hasUnresolvedRephraseAlert={false}
+              className="flex items-center justify-around sm:block"
             />
           </Col>
         )}

--- a/packages/app/components/Queue/TA/EditQueueModal.tsx
+++ b/packages/app/components/Queue/TA/EditQueueModal.tsx
@@ -227,7 +227,7 @@ export function EditQueueModal({
           <h4 className="mt-2 font-medium">Current Zoom link:</h4>
           {currentZoomLink ? (
             <a className="block text-sky-800" href={currentZoomLink}>
-              {currentZoomLink}{' '}
+              {currentZoomLink}
             </a>
           ) : (
             <p> Zoomlink not Available</p>
@@ -239,8 +239,7 @@ export function EditQueueModal({
               onChange={onZoomLinkChange}
             />
             <Button className="my-1" onClick={changeZoomLink}>
-              {' '}
-              Change Link{' '}
+              Change Link
             </Button>
           </CustomFormItem>
         </Form>

--- a/packages/app/components/Queue/TA/EditQueueModal.tsx
+++ b/packages/app/components/Queue/TA/EditQueueModal.tsx
@@ -1,6 +1,14 @@
 import { ReactElement } from 'react'
 import Modal from 'antd/lib/modal/Modal'
-import { Switch, Input, Form, Button, message, Checkbox } from 'antd'
+import {
+  Switch,
+  Input,
+  Form,
+  Button,
+  message,
+  Popconfirm,
+  Checkbox,
+} from 'antd'
 import styled from 'styled-components'
 import { API } from '@koh/api-client'
 import { useQueue } from '../../../hooks/useQueue'
@@ -9,7 +17,13 @@ import { pick } from 'lodash'
 import { default as React, useEffect, useCallback, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useCourse } from '../../../hooks/useCourse'
-import { QuestionType } from '../QueueListSharedComponents'
+import {
+  QuestionType,
+  DisableQueueButton,
+  ClearQueueButton,
+  clearQueue,
+  confirmDisable,
+} from '../QueueListSharedComponents'
 import { SketchPicker } from 'react-color'
 import { BgColorsOutlined } from '@ant-design/icons'
 
@@ -25,11 +39,18 @@ const CustomFormItem = styled(Form.Item)`
   @media (max-width: 650px) {
     padding-bottom: 1rem;
     margin-bottom: 1rem;
+    &:last-child {
+      padding-bottom: 0;
+      margin-bottom: 0;
+    }
   }
 
-  &:last-child {
-    padding-bottom: 0;
-    margin-bottom: 0;
+  @media (min-width: 650px) {
+    // the last child on desktop is actually the second last child (since the last child is the delete and clear queue buttons)
+    &:nth-last-child(2) {
+      padding-bottom: 0;
+      margin-bottom: 0;
+    }
   }
 `
 
@@ -241,6 +262,33 @@ export function EditQueueModal({
             <Button className="my-1" onClick={changeZoomLink}>
               Change Link
             </Button>
+          </CustomFormItem>
+          {/* Delete Queue and Clear Queue buttons for mobile only (normally shown on QueueListShareComponents.tsx) */}
+          <CustomFormItem className="block sm:hidden">
+            <div className="flex flex-row space-x-4">
+              <DisableQueueButton
+                onClick={() => confirmDisable(queueId, queue)}
+                data-cy="queue-disable-button"
+                disabled={queue?.isDisabled}
+                className="!w-fit"
+              >
+                {queue?.isDisabled ? `Queue deleted` : `Delete Queue`}
+              </DisableQueueButton>
+              <Popconfirm
+                title={
+                  'Are you sure you want to clear all students from the queue?'
+                }
+                okText="Yes"
+                cancelText="No"
+                placement="top"
+                arrowPointAtCenter={true}
+                onConfirm={() => clearQueue(queueId, queue)}
+              >
+                <ClearQueueButton className="!w-fit">
+                  Clear Queue
+                </ClearQueueButton>
+              </Popconfirm>
+            </div>
           </CustomFormItem>
         </Form>
       )}

--- a/packages/app/components/Queue/TA/EditQueueModal.tsx
+++ b/packages/app/components/Queue/TA/EditQueueModal.tsx
@@ -11,11 +11,26 @@ import { useRouter } from 'next/router'
 import { useCourse } from '../../../hooks/useCourse'
 import { QuestionType } from '../QueueListSharedComponents'
 import { SketchPicker } from 'react-color'
-import Icon, { BgColorsOutlined } from '@ant-design/icons'
+import { BgColorsOutlined } from '@ant-design/icons'
 
 const NotesInput = styled(Input.TextArea)`
   border-radius: 6px;
   border: 1px solid #b8c4ce;
+`
+
+const CustomFormItem = styled(Form.Item)`
+  padding-bottom: 1.75rem;
+  margin-bottom: 1.75rem;
+
+  @media (max-width: 650px) {
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  &:last-child {
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
 `
 
 interface EditQueueModalProps {
@@ -137,72 +152,97 @@ export function EditQueueModal({
     >
       {queue && (
         <Form form={form} initialValues={queue}>
-          <Form.Item label="Queue Notes" name="notes">
-            <NotesInput allowClear={true} placeholder={''} />
-          </Form.Item>
-          <Form.Item
+          <CustomFormItem
+            label="Queue Notes"
+            className="font-medium"
+            name="notes"
+          >
+            <NotesInput
+              className="font-normal"
+              allowClear={true}
+              placeholder={''}
+            />
+          </CustomFormItem>
+
+          <CustomFormItem
             label="Allow New Questions"
+            className="font-medium"
             name="allowQuestions"
             valuePropName="checked"
           >
             <Checkbox />
-          </Form.Item>
-          <h4>Current Question Types: (click to delete)</h4>
-          {questionsTypeState.length > 0 ? (
-            questionsTypeState.map((questionType, index) => (
-              <QuestionType
-                key={index}
-                typeName={questionType.name}
-                typeColor={questionType.color}
-                onClick={() => onclick(questionType.name)}
+          </CustomFormItem>
+          <h4 className="font-medium">
+            Current Question Types: (click to delete)
+          </h4>
+          <div className="my-1">
+            {questionsTypeState.length > 0 ? (
+              questionsTypeState.map((questionType, index) => (
+                <QuestionType
+                  key={index}
+                  typeName={questionType.name}
+                  typeColor={questionType.color}
+                  onClick={() => onclick(questionType.name)}
+                />
+              ))
+            ) : (
+              <p>No Questions types</p>
+            )}
+          </div>
+          <CustomFormItem name="add">
+            <div className="flex justify-between">
+              <Button onClick={() => setPickerVisible(!pickerVisible)}>
+                <BgColorsOutlined />
+              </Button>
+
+              <Input
+                allowClear={true}
+                placeholder="Enter New Question type name"
+                onChange={onAddChange}
+                maxLength={15}
+                className="mx-2 mb-2"
               />
-            ))
-          ) : (
-            <p>No Questions types</p>
-          )}
-          <Form.Item name="add">
-            <Input
-              allowClear={true}
-              placeholder="Enter New Question type name"
-              onChange={onAddChange}
-              maxLength={15}
-              style={{ marginBottom: '10px' }}
-            />
-            <Button onClick={() => setPickerVisible(!pickerVisible)}>
-              <BgColorsOutlined />
-            </Button>
+
+              <Button
+                onClick={() => {
+                  setPickerVisible(false)
+                  const randomColor =
+                    '#' + Math.floor(Math.random() * 16777215).toString(16)
+                  handleColorChange({ hex: randomColor })
+                  addQuestionType()
+                }}
+              >
+                Add
+              </Button>
+            </div>
 
             {pickerVisible && (
               <SketchPicker
+                className=""
                 color={color}
                 onChangeComplete={handleColorChange}
               />
             )}
-
-            <Button
-              onClick={() => {
-                setPickerVisible(false)
-                const randomColor =
-                  '#' + Math.floor(Math.random() * 16777215).toString(16)
-                handleColorChange({ hex: randomColor })
-                addQuestionType()
-              }}
-            >
-              Add
+          </CustomFormItem>
+          <h4 className="mt-2 font-medium">Current Zoom link:</h4>
+          {currentZoomLink ? (
+            <a className="block text-sky-800" href={currentZoomLink}>
+              {currentZoomLink}{' '}
+            </a>
+          ) : (
+            <p> Zoomlink not Available</p>
+          )}
+          <CustomFormItem>
+            <Input
+              className="my-1"
+              allowClear={true}
+              onChange={onZoomLinkChange}
+            />
+            <Button className="my-1" onClick={changeZoomLink}>
+              {' '}
+              Change Link{' '}
             </Button>
-          </Form.Item>
-          <h4 style={{ marginTop: '20px' }}>
-            Current Zoom link:{' '}
-            {currentZoomLink ? (
-              <p style={{ color: 'blue' }}>{currentZoomLink} </p>
-            ) : (
-              <p> Zoomlink not Available</p>
-            )}
-          </h4>
-          <Form.Item>
-            <Input allowClear={true} onChange={onZoomLinkChange} />
-            <Button onClick={changeZoomLink}> Change Link </Button>
-          </Form.Item>
+          </CustomFormItem>
         </Form>
       )}
     </Modal>

--- a/packages/app/components/Queue/TA/TAAddStudent.tsx
+++ b/packages/app/components/Queue/TA/TAAddStudent.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useCallback } from 'react'
 import Modal from 'antd/lib/modal/Modal'
-import { Form, Collapse, message, Checkbox } from 'antd'
+import { Form, Collapse, message, Checkbox, Input } from 'antd'
 import { API } from '@koh/api-client'
 import { default as React, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
@@ -258,11 +258,9 @@ export function AddStudentsModal({
                 </Button> */}
               </Form.Item>
             </Form>
-            {studentsState.length > 0 ? (
-              <p>Search for students to be added</p>
-            ) : (
+            {studentsState.length == 0 ? (
               <p>There are no students or all students are in queue</p>
-            )}
+            ) : null}
             {selectOptions.length > 0 ? (
               <>
                 <br />
@@ -273,7 +271,7 @@ export function AddStudentsModal({
                         <p>{option.value}</p>
                       </strong>
                       <Form.Item>
-                        <input
+                        <Input
                           placeholder={`Enter ${option.value}'s question`}
                           style={{ width: '100%', height: '40px' }}
                           onChange={(e) =>

--- a/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
@@ -41,11 +41,13 @@ export default function TAQueueDetailButtons({
   queueId,
   question,
   hasUnresolvedRephraseAlert,
+  className,
 }: {
   courseId: number
   queueId: number
   question: Question
   hasUnresolvedRephraseAlert: boolean
+  className?: string
 }): ReactElement {
   //const defaultMessage = useDefaultMessage();
   const { course } = useCourse(courseId)
@@ -218,59 +220,61 @@ export default function TAQueueDetailButtons({
     })()
     return (
       <>
-        <Popconfirm
-          title="Are you sure you want to delete this question from the queue?"
-          disabled={!isCheckedIn}
-          okText="Yes"
-          cancelText="No"
-          onConfirm={async () => {
-            await deleteQuestion()
-          }}
-        >
-          <Tooltip
-            title={
-              isCheckedIn
-                ? 'Remove From Queue'
-                : 'You must check in to remove students from the queue'
-            }
+        <div className={className}>
+          <Popconfirm
+            title="Are you sure you want to delete this question from the queue?"
+            disabled={!isCheckedIn}
+            okText="Yes"
+            cancelText="No"
+            onConfirm={async () => {
+              await deleteQuestion()
+            }}
           >
-            <span>
-              {/* This span is a workaround for tooltip-on-disabled-button 
+            <Tooltip
+              title={
+                isCheckedIn
+                  ? 'Remove From Queue'
+                  : 'You must check in to remove students from the queue'
+              }
+            >
+              <span>
+                {/* This span is a workaround for tooltip-on-disabled-button 
               https://github.com/ant-design/ant-design/issues/9581#issuecomment-599668648 */}
-              <BannerDangerButton
+                <BannerDangerButton
+                  shape="circle"
+                  icon={<DeleteOutlined />}
+                  data-cy="remove-from-queue"
+                  disabled={!isCheckedIn}
+                />
+              </span>
+            </Tooltip>
+          </Popconfirm>
+          <Tooltip title={rephraseTooltip}>
+            <span>
+              <BannerOrangeButton
                 shape="circle"
-                icon={<DeleteOutlined />}
-                data-cy="remove-from-queue"
-                disabled={!isCheckedIn}
+                icon={<QuestionOutlined />}
+                onClick={sendRephraseAlert}
+                data-cy="request-rephrase-question"
+                disabled={!canRephrase}
               />
             </span>
           </Tooltip>
-        </Popconfirm>
-        <Tooltip title={rephraseTooltip}>
-          <span>
-            <BannerOrangeButton
-              shape="circle"
-              icon={<QuestionOutlined />}
-              onClick={sendRephraseAlert}
-              data-cy="request-rephrase-question"
-              disabled={!canRephrase}
-            />
-          </span>
-        </Tooltip>
-        <Tooltip title={helpTooltip}>
-          <span>
-            <BannerPrimaryButton
-              icon={<PhoneOutlined />}
-              onClick={() => {
-                // message.success("timer cleared")
-                // clearTimeout(timerCheckout.current);
-                helpStudent()
-              }}
-              disabled={!canHelp}
-              data-cy="help-student"
-            />
-          </span>
-        </Tooltip>
+          <Tooltip title={helpTooltip}>
+            <span>
+              <BannerPrimaryButton
+                icon={<PhoneOutlined />}
+                onClick={() => {
+                  // message.success("timer cleared")
+                  // clearTimeout(timerCheckout.current);
+                  helpStudent()
+                }}
+                disabled={!canHelp}
+                data-cy="help-student"
+              />
+            </span>
+          </Tooltip>
+        </div>
       </>
     )
   }

--- a/packages/app/components/Queue/TAStatuses.tsx
+++ b/packages/app/components/Queue/TAStatuses.tsx
@@ -1,40 +1,40 @@
-import { Question } from "@koh/common";
-import { Badge, Col, Row } from "antd";
-import React, { ReactElement } from "react";
-import styled from "styled-components";
-import { useQuestions } from "../../hooks/useQuestions";
-import { useQueue } from "../../hooks/useQueue";
-import { formatWaitTime } from "../../utils/TimeUtil";
-import { KOHAvatar } from "../common/SelfAvatar";
-import { RenderEvery } from "../RenderEvery";
+import { Question } from '@koh/common'
+import { Badge, Col, Row } from 'antd'
+import React, { ReactElement } from 'react'
+import styled from 'styled-components'
+import { useQuestions } from '../../hooks/useQuestions'
+import { useQueue } from '../../hooks/useQueue'
+import { formatWaitTime } from '../../utils/TimeUtil'
+import { KOHAvatar } from '../common/SelfAvatar'
+import { RenderEvery } from '../RenderEvery'
 
 interface StatusRowProps {
-  queueId: number;
+  queueId: number
 }
 /**
  * Row of ta statuses
  */
 export function TAStatuses({ queueId }: StatusRowProps): ReactElement {
-  const { questions } = useQuestions(queueId);
+  const { questions } = useQuestions(queueId)
   const {
     queue: { staffList },
-  } = useQueue(queueId);
+  } = useQueue(queueId)
   if (!questions) {
-    return null;
+    return null
   }
 
-  const taToQuestion: Record<number, Question> = {};
-  const taIds = staffList.map((t) => t.id);
-  const helpingQuestions = questions.questionsGettingHelp;
-  const groups = questions.groups;
+  const taToQuestion: Record<number, Question> = {}
+  const taIds = staffList.map((t) => t.id)
+  const helpingQuestions = questions.questionsGettingHelp
+  const groups = questions.groups
   for (const question of helpingQuestions) {
     if (taIds.includes(question.taHelped?.id)) {
-      taToQuestion[question.taHelped.id] = question;
+      taToQuestion[question.taHelped.id] = question
     }
   }
 
   return (
-    <Col style={{ marginBottom: "16px" }}>
+    <Col style={{ marginBottom: '16px' }}>
       {staffList.map((ta) => (
         <Col key={ta.id}>
           <StatusCard
@@ -47,7 +47,7 @@ export function TAStatuses({ queueId }: StatusRowProps): ReactElement {
         </Col>
       ))}
     </Col>
-  );
+  )
 }
 
 const StyledCard = styled.div`
@@ -57,27 +57,33 @@ const StyledCard = styled.div`
   padding: 16px;
   display: flex;
   margin-bottom: 16px;
-`;
+
+  /* decrease margins and padding on mobile */
+  @media (max-width: 650px) {
+    padding: 12px;
+    margin-bottom: 8px;
+  }
+`
 
 const CardContent = styled.div`
   margin-left: 16px;
   flex-grow: 1;
-`;
+`
 const TAName = styled.div`
   font-weight: bold;
   color: #212934;
-`;
+`
 const HelpingInfo = styled.div`
   margin-top: 5px;
   font-style: italic;
-`;
+`
 
 interface StatusCardProps {
-  taName: string;
-  taPhotoURL: string;
-  studentName?: string;
-  helpedAt?: Date;
-  grouped?: boolean;
+  taName: string
+  taPhotoURL: string
+  studentName?: string
+  helpedAt?: Date
+  grouped?: boolean
 }
 /**
  * View component just renders TA status
@@ -89,7 +95,7 @@ function StatusCard({
   helpedAt,
   grouped,
 }: StatusCardProps): ReactElement {
-  const isBusy = !!helpedAt;
+  const isBusy = !!helpedAt
   return (
     <StyledCard data-cy="ta-status-card">
       <KOHAvatar
@@ -102,37 +108,37 @@ function StatusCard({
         <Row justify="space-between">
           <TAName>{taName}</TAName>
           <span>
-            <Badge status={isBusy ? "processing" : "success"} />
-            {isBusy ? "Busy" : "Available"}
+            <Badge status={isBusy ? 'processing' : 'success'} />
+            {isBusy ? 'Busy' : 'Available'}
           </span>
         </Row>
         <HelpingInfo>
           {grouped ? (
-            "Helping a group"
+            'Helping a group'
           ) : isBusy ? (
             <HelpingFor studentName={studentName} helpedAt={helpedAt} />
           ) : (
-            "Looking for my next student..."
+            'Looking for my next student...'
           )}
         </HelpingInfo>
       </CardContent>
     </StyledCard>
-  );
+  )
 }
 
 const BlueSpan = styled.span`
   color: #66a3d6;
-`;
+`
 interface HelpingForProps {
-  studentName: string;
-  helpedAt: Date;
+  studentName: string
+  helpedAt: Date
 }
 function HelpingFor({ studentName, helpedAt }: HelpingForProps): ReactElement {
   return (
     <RenderEvery
       render={() => (
         <span>
-          Helping <BlueSpan>{studentName ?? "a student"}</BlueSpan> for{" "}
+          Helping <BlueSpan>{studentName ?? 'a student'}</BlueSpan> for{' '}
           <BlueSpan>
             {formatWaitTime((Date.now() - helpedAt.getTime()) / 60000)}
           </BlueSpan>
@@ -140,5 +146,5 @@ function HelpingFor({ studentName, helpedAt }: HelpingForProps): ReactElement {
       )}
       interval={60 * 1000}
     />
-  );
+  )
 }

--- a/packages/app/components/Queue/TAStatuses.tsx
+++ b/packages/app/components/Queue/TAStatuses.tsx
@@ -34,7 +34,7 @@ export function TAStatuses({ queueId }: StatusRowProps): ReactElement {
   }
 
   return (
-    <Col style={{ marginBottom: '16px' }}>
+    <Col className="mb-3 sm:mb-0">
       {staffList.map((ta) => (
         <Col key={ta.id}>
           <StatusCard

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -1,19 +1,10 @@
 import {
   EditOutlined,
   NotificationOutlined,
+  RightOutlined,
   StopOutlined,
 } from '@ant-design/icons'
-import {
-  Button,
-  Card,
-  Divider,
-  Input,
-  Row,
-  Skeleton,
-  Space,
-  Tag,
-  Tooltip,
-} from 'antd'
+import { Button, Card, Divider, Input, Row, Skeleton, Tag, Tooltip } from 'antd'
 import Linkify from 'react-linkify'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -28,16 +19,38 @@ type QueueCard = {
   updateQueueNotes: (queue: QueuePartial, queueNotes: string) => Promise<void>
 }
 
-const PaddedCard = styled(Card)`
+const CustomCard = styled(Card)`
   margin-top: 32px;
   margin-bottom: 25px;
   border-radius: 6px;
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
-`
 
-const HeaderDiv = styled.div`
-  font-size: 14px;
-  color: #212934;
+  // make the box shadow more pronounced on mobile to make it look more clickable
+  @media (max-width: 650px) {
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .ant-card-body {
+    padding-top: 16px;
+  }
+
+  // hover effect
+  transition: box-shadow 0.3s ease;
+  &:hover {
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.45);
+    // background: rgba(235, 235, 235);
+
+    .ant-card-head {
+      background: rgb(47, 76, 128) !important;
+      transition: color 0.3s ease-in-out !important;
+    }
+
+    // make the green arrow right on hover (still uncertain on whether to keep this)
+    .anticon.anticon-right {
+      color: lightgreen;
+      transition: color 0.3s ease-in-out;
+    }
+  }
 `
 
 const QueueInfoRow = styled.div`
@@ -47,37 +60,8 @@ const QueueInfoRow = styled.div`
   align-items: center;
 `
 
-const RightQueueInfoRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`
-
 const QueueInfoTags = styled.div`
   display: flex;
-`
-
-const QuestionNumberSpan = styled.span`
-  font-size: 18px;
-`
-
-const QueueSizeSpan = styled.span`
-  font-size: 18px;
-`
-
-const HeaderText = styled.div`
-  font-size: 14px;
-  line-height: 22px;
-  font-weight: 600;
-  color: #bfbfbf;
-  font-variant: small-caps;
-  margin-bottom: 8px;
-`
-
-const OpenQueueButton = styled(Button)`
-  border-radius: 6px;
-  font-size: 14px;
-  margin-left: 16px;
 `
 
 const EditNotesButton = styled(Button)`
@@ -115,6 +99,7 @@ const NotesInput = styled(Input.TextArea)`
 const Notes = styled.div`
   overflow-wrap: break-word;
   white-space: pre-wrap;
+  color: rgb(125, 125, 125);
 `
 
 const StyledKOHAvatar = styled(KOHAvatar)`
@@ -141,151 +126,145 @@ const QueueCard = ({
 }: QueueCard): ReactElement => {
   const [editingNotes, setEditingNotes] = useState(false)
   const [updatedNotes, setUpdatedNotes] = useState(queue.notes)
+  const [isLinkEnabled, setIsLinkEnabled] = useState(true) // for enabling/disabling the link to the queue when editing notes
   const router = useRouter()
   const { cid } = router.query
 
   const staffList = queue.staffList
 
-  const handleUpdate = () => {
+  const handleUpdate = (e) => {
+    e.stopPropagation()
+    setIsLinkEnabled(true)
     setEditingNotes(false)
     updateQueueNotes(queue, updatedNotes)
   }
   return (
-    <PaddedCard
-      headStyle={{
-        background: queue.isOpen ? '#25426C' : '#25426cbf',
-        color: '#FFFFFF',
-        borderRadius: '6px 6px 0 0',
-      }}
-      // make the card glow if there are staff members in the queue
-      className={
-        'open-queue-card ' + (queue.staffList.length >= 1 ? 'glowy' : '')
-      }
-      title={
-        <span>
-          {queue.room}{' '}
-          <QueueInfoTags>
-            {queue?.isProfessorQueue && (
-              <Tag color="#337589" className="m-0 mr-1 text-gray-200">
-                Professor Queue
-              </Tag>
-            )}
-            {queue.isOpen && !queue.allowQuestions && (
-              <Tooltip title="This queue is no longer accepting questions">
-                <Tag
-                  icon={<StopOutlined />}
-                  color="#591e40"
-                  className="m-0 text-gray-300"
-                >
-                  Not Accepting Questions
-                </Tag>
-              </Tooltip>
-            )}
-          </QueueInfoTags>{' '}
-        </span>
-      }
-      extra={
-        <span>
-          <QueueSizeSpan>{queue.queueSize}</QueueSizeSpan> in queue
-        </span>
-      }
+    <Link
+      href={isLinkEnabled ? '/course/[cid]/queue/[qid]' : ''}
+      as={isLinkEnabled ? `/course/${cid}/queue/${queue.id}` : ''}
     >
-      <QueueInfoRow>
-        <HeaderDiv>
-          <QuestionNumberSpan>{queue.staffList.length}</QuestionNumberSpan>{' '}
-          staff checked in
-        </HeaderDiv>
-        <RightQueueInfoRow>
-          <Space direction="vertical" align="end" size="middle">
-            <Link
-              href="/course/[cid]/queue/[qid]"
-              as={`/course/${cid}/queue/${queue.id}`}
-            >
-              <OpenQueueButton
-                size="large"
-                data-cy="open-queue-button"
-                type={queue.staffList.length >= 1 ? 'primary' : 'default'}
-              >
-                Open Queue ＞
-              </OpenQueueButton>
-            </Link>
-          </Space>
-        </RightQueueInfoRow>
-      </QueueInfoRow>
-      {
-        staffList.length > 1 && (
-          <HeaderText>checked-in staff</HeaderText>
-        ) /*todo: add better text*/
-      }
+      <CustomCard
+        headStyle={{
+          background: queue.isOpen ? '#25426C' : '#25426cbf',
+          color: '#FFFFFF',
+          borderRadius: '6px 6px 0 0',
+        }}
+        // make the card glow if there are staff members in the queue
+        className={
+          'open-queue-card' +
+          (queue.staffList.length >= 1 ? ' glowy ' : '') +
+          (isLinkEnabled ? ' cursor-pointer ' : '')
+        }
+        title={
+          <span className="mr-8 flex flex-row flex-wrap items-center justify-between">
+            <div>
+              {queue.room}
 
-      <Row justify="space-between" align="middle">
-        <div>
-          {staffList.map((staffMember) => (
-            <Tooltip key={staffMember.id} title={staffMember.name}>
-              <StyledKOHAvatar
-                size={48}
-                photoURL={staffMember.photoURL}
-                name={staffMember.name}
-              />
-            </Tooltip>
-          ))}
+              <QueueInfoTags>
+                {queue?.isProfessorQueue && (
+                  <Tag color="#337589" className="m-0 mr-1 text-gray-200">
+                    Professor Queue
+                  </Tag>
+                )}
+                {queue.isOpen && !queue.allowQuestions && (
+                  <Tooltip title="This queue is no longer accepting questions">
+                    <Tag
+                      icon={<StopOutlined />}
+                      color="#591e40"
+                      className="m-0 text-gray-300"
+                    >
+                      Not Accepting Questions
+                    </Tag>
+                  </Tooltip>
+                )}
+              </QueueInfoTags>
+            </div>
+            <div className="mr-8 h-fit text-sm font-normal text-gray-200">
+              <span className="text-lg font-medium">{queue.queueSize}</span> in
+              queue
+            </div>
+          </span>
+        }
+        extra={<RightOutlined className=" text-3xl text-gray-100" />}
+      >
+        <div className="flex flex-row items-center justify-start">
+          <div className=" mr-3 text-sm">
+            <span className=" text-base">{queue.staffList.length} </span>
+            staff checked in{queue.staffList.length > 0 ? ':' : ''}
+          </div>
+          <div>
+            {staffList.map((staffMember) => (
+              <Tooltip key={staffMember.id} title={staffMember.name}>
+                <StyledKOHAvatar
+                  size={48}
+                  photoURL={staffMember.photoURL}
+                  name={staffMember.name}
+                />
+              </Tooltip>
+            ))}
+          </div>
         </div>
-        <QueueCardDivider />
-        {/* If notes being edited, show input box.
+
+        <Row justify="space-between" align="middle">
+          <QueueCardDivider />
+          {/* If notes being edited, show input box.
           Else if there are notes, show the notes.
           Else if you're a TA, show placeholder.
           Else show nothing */}
-        {editingNotes ? (
-          <NotesDiv>
-            <NotesInput
-              defaultValue={queue.notes}
-              value={updatedNotes}
-              onChange={(e) => setUpdatedNotes(e.target.value as any)}
-            />
-          </NotesDiv>
-        ) : queue.notes ? (
-          <div>
-            <Linkify
-              componentDecorator={(decoratedHref, decoratedText, key) => (
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={decoratedHref}
-                  key={key}
-                >
-                  {decoratedText}
-                </a>
-              )}
-            >
-              <Notes>
-                <NotificationOutlined /> <i>{queue.notes}</i>
-              </Notes>
-            </Linkify>
-          </div>
-        ) : isTA ? (
-          <i className="text-gray-400"> no notes provided </i>
-        ) : null}
-        <RightQueueNotesRow>
-          {editingNotes && (
-            <SaveButton onClick={handleUpdate} size="large">
-              Save Changes
-            </SaveButton>
-          )}
-          {!editingNotes && (
-            <QueueCardButtonRow>
-              {isTA && (
-                <EditNotesButton
-                  onClick={() => {
-                    setEditingNotes(true)
-                  }}
-                  icon={<EditOutlined />}
-                />
-              )}
-            </QueueCardButtonRow>
-          )}
-        </RightQueueNotesRow>
-      </Row>
-    </PaddedCard>
+          {editingNotes ? (
+            <NotesDiv>
+              <NotesInput
+                defaultValue={queue.notes}
+                value={updatedNotes}
+                onChange={(e) => setUpdatedNotes(e.target.value as any)}
+              />
+            </NotesDiv>
+          ) : queue.notes ? (
+            <div>
+              <Linkify
+                componentDecorator={(decoratedHref, decoratedText, key) => (
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={decoratedHref}
+                    key={key}
+                  >
+                    {decoratedText}
+                  </a>
+                )}
+              >
+                <Notes>
+                  <NotificationOutlined /> <i>{queue.notes}</i>
+                </Notes>
+              </Linkify>
+            </div>
+          ) : isTA ? (
+            <i className="font-light text-gray-400"> no notes provided </i>
+          ) : null}
+          <RightQueueNotesRow>
+            {editingNotes && (
+              <SaveButton onClick={handleUpdate} size="large">
+                Save Changes
+              </SaveButton>
+            )}
+            {!editingNotes && (
+              <QueueCardButtonRow>
+                {isTA && (
+                  <EditNotesButton
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setIsLinkEnabled(false)
+                      setEditingNotes(true)
+                    }}
+                    icon={<EditOutlined />}
+                  />
+                )}
+              </QueueCardButtonRow>
+            )}
+          </RightQueueNotesRow>
+        </Row>
+      </CustomCard>
+    </Link>
   )
 }
 
@@ -293,7 +272,7 @@ export default QueueCard
 
 export function QueueCardSkeleton(): ReactElement {
   return (
-    <PaddedCard
+    <CustomCard
       headStyle={{
         background: '#25426C',
         color: '#FFFFFF',
@@ -312,6 +291,6 @@ export function QueueCardSkeleton(): ReactElement {
         <NotesSkeleton title={false} paragraph={{ rows: 1 }} />
         <Skeleton.Button size="large" style={{ marginTop: '12px' }} />
       </Row>
-    </PaddedCard>
+    </CustomCard>
   )
 }

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -199,7 +199,7 @@ const QueueCard = ({
                 data-cy="open-queue-button"
                 type="primary"
               >
-                Open Queue
+                Open Queue ＞
               </OpenQueueButton>
             </Link>
           </Space>

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -162,7 +162,7 @@ const QueueCard = ({
           {queue.room}{' '}
           <QueueInfoTags>
             {queue?.isProfessorQueue && (
-              <Tag color="#337589" style={{ margin: 0 }}>
+              <Tag color="#337589" className="m-0 text-gray-200">
                 Professor Queue
               </Tag>
             )}
@@ -170,8 +170,8 @@ const QueueCard = ({
               <Tooltip title="This queue is no longer accepting questions">
                 <Tag
                   icon={<StopOutlined />}
-                  color="#6C2526"
-                  style={{ margin: 0 }}
+                  color="#591e40"
+                  className="m-0 text-gray-300"
                 >
                   Not Accepting Questions
                 </Tag>

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -247,11 +247,7 @@ const QueueCard = ({
               </Notes>
             </Linkify>
           </div>
-        ) : (
-          <div>
-            <i> no notes provided</i>
-          </div>
-        )}
+        ) : null}
         <RightQueueNotesRow>
           {editingNotes && (
             <SaveButton onClick={handleUpdate} size="large">

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -166,7 +166,7 @@ const QueueCard = ({
           {queue.room}{' '}
           <QueueInfoTags>
             {queue?.isProfessorQueue && (
-              <Tag color="#337589" className="m-0 text-gray-200">
+              <Tag color="#337589" className="m-0 mr-1 text-gray-200">
                 Professor Queue
               </Tag>
             )}

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -40,6 +40,7 @@ const QueueInfoRow = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
 `
 
 const RightQueueInfoRow = styled.div`
@@ -113,8 +114,7 @@ const Notes = styled.div`
 `
 
 const StyledKOHAvatar = styled(KOHAvatar)`
-  margin-right: 25px;
-  margin-top: 10px;
+  margin-right: 1rem;
 `
 
 const QueueCardButtonRow = styled(Row)`
@@ -154,7 +154,29 @@ const QueueCard = ({
         borderRadius: '6px 6px 0 0',
       }}
       className={'open-queue-card'}
-      title={<span>{queue.room} </span>}
+      title={
+        <span>
+          {queue.room}{' '}
+          <QueueInfoTags>
+            {queue?.isProfessorQueue && (
+              <Tag color="#337589" style={{ margin: 0 }}>
+                Professor Queue
+              </Tag>
+            )}
+            {queue.isOpen && !queue.allowQuestions && (
+              <Tooltip title="This queue is no longer accepting questions">
+                <Tag
+                  icon={<StopOutlined />}
+                  color="#6C2526"
+                  style={{ margin: 0 }}
+                >
+                  Not Accepting Questions
+                </Tag>
+              </Tooltip>
+            )}
+          </QueueInfoTags>{' '}
+        </span>
+      }
       extra={
         <span>
           <QueueSizeSpan>{queue.queueSize}</QueueSizeSpan> in queue
@@ -168,24 +190,6 @@ const QueueCard = ({
         </HeaderDiv>
         <RightQueueInfoRow>
           <Space direction="vertical" align="end" size="middle">
-            <QueueInfoTags>
-              {queue?.isProfessorQueue && (
-                <Tag color="blue" style={{ margin: 0 }}>
-                  Professor Queue
-                </Tag>
-              )}
-              {queue.isOpen && !queue.allowQuestions && (
-                <Tooltip title="This queue is no longer accepting questions">
-                  <Tag
-                    icon={<StopOutlined />}
-                    color="error"
-                    style={{ margin: '0px 0px 0px 8px' }}
-                  >
-                    Not Accepting Questions
-                  </Tag>
-                </Tooltip>
-              )}
-            </QueueInfoTags>
             <Link
               href="/course/[cid]/queue/[qid]"
               as={`/course/${cid}/queue/${queue.id}`}

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -153,7 +153,10 @@ const QueueCard = ({
         color: '#FFFFFF',
         borderRadius: '6px 6px 0 0',
       }}
-      className={'open-queue-card'}
+      // make the card glow if there are staff members in the queue
+      className={
+        'open-queue-card ' + (queue.staffList.length >= 1 ? 'glowy' : '')
+      }
       title={
         <span>
           {queue.room}{' '}
@@ -197,7 +200,7 @@ const QueueCard = ({
               <OpenQueueButton
                 size="large"
                 data-cy="open-queue-button"
-                type="primary"
+                type={(queue.staffList.length >= 1 ? 'primary' : 'secondary')}
               >
                 Open Queue ＞
               </OpenQueueButton>

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -32,7 +32,7 @@ const PaddedCard = styled(Card)`
 `
 
 const HeaderDiv = styled.div`
-  font-size: 18px;
+  font-size: 14px;
   color: #212934;
 `
 
@@ -53,7 +53,7 @@ const QueueInfoTags = styled.div`
 `
 
 const QuestionNumberSpan = styled.span`
-  font-size: 24px;
+  font-size: 18px;
 `
 
 const QueueSizeSpan = styled.span`
@@ -212,7 +212,7 @@ const QueueCard = ({
           {staffList.map((staffMember) => (
             <Tooltip key={staffMember.id} title={staffMember.name}>
               <StyledKOHAvatar
-                size={96}
+                size={48}
                 photoURL={staffMember.photoURL}
                 name={staffMember.name}
               />

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -38,7 +38,6 @@ const CustomCard = styled(Card)`
   transition: box-shadow 0.3s ease;
   &:hover {
     box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.45);
-    // background: rgba(235, 235, 235);
 
     .ant-card-head {
       background: rgb(47, 76, 128) !important;

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -1,4 +1,8 @@
-import { NotificationOutlined, StopOutlined } from '@ant-design/icons'
+import {
+  EditOutlined,
+  NotificationOutlined,
+  StopOutlined,
+} from '@ant-design/icons'
 import {
   Button,
   Card,
@@ -227,6 +231,10 @@ const QueueCard = ({
           ))}
         </div>
         <QueueCardDivider />
+        {/* If notes being edited, show input box.
+          Else if there are notes, show the notes.
+          Else if you're a TA, show placeholder.
+          Else show nothing */}
         {editingNotes ? (
           <NotesDiv>
             <NotesInput
@@ -254,6 +262,8 @@ const QueueCard = ({
               </Notes>
             </Linkify>
           </div>
+        ) : isTA ? (
+          <i className="text-gray-400"> no notes provided </i>
         ) : null}
         <RightQueueNotesRow>
           {editingNotes && (
@@ -265,13 +275,11 @@ const QueueCard = ({
             <QueueCardButtonRow>
               {isTA && (
                 <EditNotesButton
-                  size="large"
                   onClick={() => {
                     setEditingNotes(true)
                   }}
-                >
-                  Edit Notes
-                </EditNotesButton>
+                  icon={<EditOutlined />}
+                />
               )}
             </QueueCardButtonRow>
           )}

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -200,7 +200,7 @@ const QueueCard = ({
               <OpenQueueButton
                 size="large"
                 data-cy="open-queue-button"
-                type={(queue.staffList.length >= 1 ? 'primary' : 'secondary')}
+                type={queue.staffList.length >= 1 ? 'primary' : 'default'}
               >
                 Open Queue ＞
               </OpenQueueButton>

--- a/packages/app/components/Today/QueueCard.tsx
+++ b/packages/app/components/Today/QueueCard.tsx
@@ -1,4 +1,4 @@
-import { NotificationOutlined, StopOutlined } from "@ant-design/icons";
+import { NotificationOutlined, StopOutlined } from '@ant-design/icons'
 import {
   Button,
   Card,
@@ -8,57 +8,57 @@ import {
   Skeleton,
   Space,
   Tag,
-  Tooltip
-} from "antd";
-import Linkify from "react-linkify";
-import Link from "next/link";
-import { useRouter } from "next/router";
-import React, { ReactElement, useState } from "react";
-import styled from "styled-components";
-import { QueuePartial } from "../../../common/index";
-import { KOHAvatar } from "../common/SelfAvatar";
+  Tooltip,
+} from 'antd'
+import Linkify from 'react-linkify'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import React, { ReactElement, useState } from 'react'
+import styled from 'styled-components'
+import { QueuePartial } from '../../../common/index'
+import { KOHAvatar } from '../common/SelfAvatar'
 
 type QueueCard = {
-  queue: QueuePartial;
-  isTA: boolean;
-  updateQueueNotes: (queue: QueuePartial, queueNotes: string) => Promise<void>;
-};
+  queue: QueuePartial
+  isTA: boolean
+  updateQueueNotes: (queue: QueuePartial, queueNotes: string) => Promise<void>
+}
 
 const PaddedCard = styled(Card)`
   margin-top: 32px;
   margin-bottom: 25px;
   border-radius: 6px;
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
-`;
+`
 
 const HeaderDiv = styled.div`
   font-size: 18px;
   color: #212934;
-`;
+`
 
 const QueueInfoRow = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-`;
+`
 
 const RightQueueInfoRow = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-`;
+`
 
 const QueueInfoTags = styled.div`
   display: flex;
-`;
+`
 
 const QuestionNumberSpan = styled.span`
   font-size: 24px;
-`;
+`
 
 const QueueSizeSpan = styled.span`
   font-size: 18px;
-`;
+`
 
 const HeaderText = styled.div`
   font-size: 14px;
@@ -67,21 +67,19 @@ const HeaderText = styled.div`
   color: #bfbfbf;
   font-variant: small-caps;
   margin-bottom: 8px;
-`;
+`
 
 const OpenQueueButton = styled(Button)`
-  color: #5f6b79;
   border-radius: 6px;
-  font-weight: 500;
   font-size: 14px;
   margin-left: 16px;
-`;
+`
 
 const EditNotesButton = styled(Button)`
   border-radius: 6px;
   font-size: 14px;
   font-weight: 500;
-`;
+`
 
 const SaveButton = styled(Button)`
   background: #2a9187;
@@ -89,73 +87,73 @@ const SaveButton = styled(Button)`
   color: white;
   font-weight: 500;
   font-size: 14px;
-`;
+`
 
 const NotesDiv = styled.div`
   display: flex;
   flex-direction: row;
   flex-grow: 1;
   margin: 10px 10px auto 0;
-`;
+`
 
 const RightQueueNotesRow = styled.div`
   display: flex;
-`;
+`
 const NotesInput = styled(Input.TextArea)`
   border-radius: 6px;
   border: 1px solid #b8c4ce;
   //display: flex;
   //flex-grow: 1;
   margin: auto 0px auto 10px;
-`;
+`
 
 const Notes = styled.div`
   overflow-wrap: break-word;
   white-space: pre-wrap;
-`;
+`
 
 const StyledKOHAvatar = styled(KOHAvatar)`
   margin-right: 25px;
   margin-top: 10px;
-`;
+`
 
 const QueueCardButtonRow = styled(Row)`
   padding-top: 10px;
-`;
+`
 
 const QueueCardDivider = styled(Divider)`
   margin-top: 12px;
   margin-bottom: 0;
-`;
+`
 
 const NotesSkeleton = styled(Skeleton)`
   width: 60%;
-`;
+`
 
 const QueueCard = ({
   queue,
   isTA,
-  updateQueueNotes
+  updateQueueNotes,
 }: QueueCard): ReactElement => {
-  const [editingNotes, setEditingNotes] = useState(false);
-  const [updatedNotes, setUpdatedNotes] = useState(queue.notes);
-  const router = useRouter();
-  const { cid } = router.query;
+  const [editingNotes, setEditingNotes] = useState(false)
+  const [updatedNotes, setUpdatedNotes] = useState(queue.notes)
+  const router = useRouter()
+  const { cid } = router.query
 
-  const staffList = queue.staffList;
+  const staffList = queue.staffList
 
   const handleUpdate = () => {
-    setEditingNotes(false);
-    updateQueueNotes(queue, updatedNotes);
-  };
+    setEditingNotes(false)
+    updateQueueNotes(queue, updatedNotes)
+  }
   return (
     <PaddedCard
       headStyle={{
-        background: queue.isOpen ? "#25426C" : "#25426cbf",
-        color: "#FFFFFF",
-        borderRadius: "6px 6px 0 0"
+        background: queue.isOpen ? '#25426C' : '#25426cbf',
+        color: '#FFFFFF',
+        borderRadius: '6px 6px 0 0',
       }}
-      className={"open-queue-card"}
+      className={'open-queue-card'}
       title={<span>{queue.room} </span>}
       extra={
         <span>
@@ -165,7 +163,7 @@ const QueueCard = ({
     >
       <QueueInfoRow>
         <HeaderDiv>
-          <QuestionNumberSpan>{queue.staffList.length}</QuestionNumberSpan>{" "}
+          <QuestionNumberSpan>{queue.staffList.length}</QuestionNumberSpan>{' '}
           staff checked in
         </HeaderDiv>
         <RightQueueInfoRow>
@@ -181,7 +179,7 @@ const QueueCard = ({
                   <Tag
                     icon={<StopOutlined />}
                     color="error"
-                    style={{ margin: "0px 0px 0px 8px" }}
+                    style={{ margin: '0px 0px 0px 8px' }}
                   >
                     Not Accepting Questions
                   </Tag>
@@ -193,9 +191,9 @@ const QueueCard = ({
               as={`/course/${cid}/queue/${queue.id}`}
             >
               <OpenQueueButton
-                style={{}}
                 size="large"
                 data-cy="open-queue-button"
+                type="primary"
               >
                 Open Queue
               </OpenQueueButton>
@@ -203,13 +201,15 @@ const QueueCard = ({
           </Space>
         </RightQueueInfoRow>
       </QueueInfoRow>
-      {staffList.length > 1 && (
-        <HeaderText>checked-in staff</HeaderText>
-      ) /*todo: add better text*/}
+      {
+        staffList.length > 1 && (
+          <HeaderText>checked-in staff</HeaderText>
+        ) /*todo: add better text*/
+      }
 
       <Row justify="space-between" align="middle">
         <div>
-          {staffList.map(staffMember => (
+          {staffList.map((staffMember) => (
             <Tooltip key={staffMember.id} title={staffMember.name}>
               <StyledKOHAvatar
                 size={96}
@@ -225,7 +225,7 @@ const QueueCard = ({
             <NotesInput
               defaultValue={queue.notes}
               value={updatedNotes}
-              onChange={e => setUpdatedNotes(e.target.value as any)}
+              onChange={(e) => setUpdatedNotes(e.target.value as any)}
             />
           </NotesDiv>
         ) : queue.notes ? (
@@ -264,7 +264,7 @@ const QueueCard = ({
                 <EditNotesButton
                   size="large"
                   onClick={() => {
-                    setEditingNotes(true);
+                    setEditingNotes(true)
                   }}
                 >
                   Edit Notes
@@ -275,20 +275,20 @@ const QueueCard = ({
         </RightQueueNotesRow>
       </Row>
     </PaddedCard>
-  );
-};
+  )
+}
 
-export default QueueCard;
+export default QueueCard
 
 export function QueueCardSkeleton(): ReactElement {
   return (
     <PaddedCard
       headStyle={{
-        background: "#25426C",
-        color: "#FFFFFF",
-        borderRadius: "6px 6px 0 0"
+        background: '#25426C',
+        color: '#FFFFFF',
+        borderRadius: '6px 6px 0 0',
       }}
-      className={"open-queue-card"}
+      className={'open-queue-card'}
       title={<Skeleton title={false} paragraph={{ rows: 1 }} />}
     >
       <QueueInfoRow>
@@ -299,8 +299,8 @@ export function QueueCardSkeleton(): ReactElement {
       <QueueCardDivider />
       <Row justify="space-between" align="bottom">
         <NotesSkeleton title={false} paragraph={{ rows: 1 }} />
-        <Skeleton.Button size="large" style={{ marginTop: "12px" }} />
+        <Skeleton.Button size="large" style={{ marginTop: '12px' }} />
       </Row>
     </PaddedCard>
-  );
+  )
 }

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -114,6 +114,7 @@ export default function TodayPageCheckinButton({
           size="large"
           data-cy="check-in-modal-button"
           onClick={() => renderProperModal()}
+          className="w-1/4"
         >
           Check In
         </CheckinButton>
@@ -123,6 +124,7 @@ export default function TodayPageCheckinButton({
           courseId={Number(cid)}
           room={queueCheckedIn.room}
           state="CheckedIn"
+          className="w-1/4"
         />
       )}
     </>

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -9,6 +9,7 @@ import { useRoleInCourse } from '../../hooks/useRoleInCourse'
 import QueueCheckInModal from './QueueCheckInModal'
 import QueueCreateModal from './QueueCreateModal'
 import TACheckinButton, { CheckinButton } from './TACheckinButton'
+import { LoginOutlined } from '@ant-design/icons'
 
 interface TodayPageCheckinButtonProps {
   createQueueModalVisible: boolean
@@ -114,7 +115,8 @@ export default function TodayPageCheckinButton({
           size="large"
           data-cy="check-in-modal-button"
           onClick={() => renderProperModal()}
-          className="w-1/4"
+          className="w-fit"
+          icon={<LoginOutlined />}
         >
           Check In
         </CheckinButton>
@@ -124,7 +126,7 @@ export default function TodayPageCheckinButton({
           courseId={Number(cid)}
           room={queueCheckedIn.room}
           state="CheckedIn"
-          className="w-1/4"
+          className="w-fit"
         />
       )}
     </>

--- a/packages/app/components/Today/TACheckinButton.tsx
+++ b/packages/app/components/Today/TACheckinButton.tsx
@@ -1,9 +1,9 @@
-import { API } from "@koh/api-client";
-import { Button, message } from "antd";
-import { useRouter } from "next/router";
-import { ReactElement } from "react";
-import styled from "styled-components";
-import { useCourse } from "../../hooks/useCourse";
+import { API } from '@koh/api-client'
+import { Button, message } from 'antd'
+import { useRouter } from 'next/router'
+import { ReactElement } from 'react'
+import styled from 'styled-components'
+import { useCourse } from '../../hooks/useCourse'
 
 export const CheckinButton = styled(Button)`
   background: #1890ff;
@@ -11,83 +11,85 @@ export const CheckinButton = styled(Button)`
   color: white;
   font-weight: 500;
   font-size: 14px;
-`;
+  width: 100%;
+`
 
 export const CheckOutButton = styled(Button)`
   color: #da3236;
   font-weight: 500;
   font-size: 14px;
   border-radius: 6px;
-`;
+  width: 100%;
+`
 
 type CheckInButtonState =
-  | "CheckedIn"
-  | "CheckedOut"
-  | "CheckedIntoOtherQueueAlready";
+  | 'CheckedIn'
+  | 'CheckedOut'
+  | 'CheckedIntoOtherQueueAlready'
 
 interface TACheckinButtonProps {
-  courseId: number;
-  room: string; // name of room to check into
-  state: CheckInButtonState; // State of the button
-  disabled?: boolean;
-  block?: boolean;
+  courseId: number
+  room: string // name of room to check into
+  state: CheckInButtonState // State of the button
+  disabled?: boolean
+  block?: boolean
 }
 export default function TACheckinButton({
   courseId,
   room,
   state,
   disabled = false,
-  block = false,
 }: TACheckinButtonProps): ReactElement {
-  const router = useRouter();
+  const router = useRouter()
 
-  const { course, mutateCourse } = useCourse(courseId);
+  const { course, mutateCourse } = useCourse(courseId)
   async function checkInTA() {
     // to see old check in in person functionality look at commit b4768bbfb0f36444c80961703bdbba01ff4a5596
     //trying to limit changes to the frontend, all queues will have the room online
 
     try {
-      const redirectID = await API.taStatus.checkIn(courseId, room);
-      mutateCourse();
+      const redirectID = await API.taStatus.checkIn(courseId, room)
+      mutateCourse()
       //3 hrs before checking a TA out
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const checkoutTimer = setTimeout(async () => {
-        message.warning("You are checked out automatically after 3 hours");
-        await API.taStatus.checkOut(courseId, room);
-        mutateCourse();
-      }, 1000 * 60 * 60 * 3);
+      const checkoutTimer = setTimeout(
+        async () => {
+          message.warning('You are checked out automatically after 3 hours')
+          await API.taStatus.checkOut(courseId, room)
+          mutateCourse()
+        },
+        1000 * 60 * 60 * 3,
+      )
 
       router.push(
-        "/course/[cid]/queue/[qid]",
-        `/course/${courseId}/queue/${redirectID.id}`
-      );
+        '/course/[cid]/queue/[qid]',
+        `/course/${courseId}/queue/${redirectID.id}`,
+      )
     } catch (err) {
-      message.error(err.response?.data?.message);
+      message.error(err.response?.data?.message)
     }
   }
 
   return (
     <>
-      {state === "CheckedIn" && (
+      {state === 'CheckedIn' && (
         <CheckOutButton
           type="default"
           size="large"
           disabled={disabled}
-          block={block}
           data-cy="check-out-button"
           onClick={async () => {
-            await API.taStatus.checkOut(courseId, room);
-            mutateCourse();
+            await API.taStatus.checkOut(courseId, room)
+            mutateCourse()
           }}
         >
           Check Out
         </CheckOutButton>
       )}
-      {state === "CheckedOut" && (
+      {state === 'CheckedOut' && (
         <CheckinButton
           type="default"
           size="large"
-          block={block}
           onClick={() => checkInTA()}
           disabled={disabled || !course}
           data-cy="check-in-button"
@@ -96,5 +98,5 @@ export default function TACheckinButton({
         </CheckinButton>
       )}
     </>
-  );
+  )
 }

--- a/packages/app/components/Today/TACheckinButton.tsx
+++ b/packages/app/components/Today/TACheckinButton.tsx
@@ -11,11 +11,9 @@ export const CheckinButton = styled(Button)`
   color: white;
   font-weight: 500;
   font-size: 14px;
-  width: 100%;
   margin-bottom: 12px;
 
   @media (max-width: 650px) {
-    width: 30%;
     margin-bottom: 0px;
   }
 `
@@ -25,11 +23,9 @@ export const CheckOutButton = styled(Button)`
   font-weight: 500;
   font-size: 14px;
   border-radius: 6px;
-  width: 100%;
   margin-bottom: 12px;
 
   @media (max-width: 650px) {
-    width: 30%;
     margin-bottom: 0px;
   }
 `
@@ -44,13 +40,14 @@ interface TACheckinButtonProps {
   room: string // name of room to check into
   state: CheckInButtonState // State of the button
   disabled?: boolean
-  block?: boolean
+  className?: string
 }
 export default function TACheckinButton({
   courseId,
   room,
   state,
   disabled = false,
+  className,
 }: TACheckinButtonProps): ReactElement {
   const router = useRouter()
 
@@ -94,6 +91,7 @@ export default function TACheckinButton({
             await API.taStatus.checkOut(courseId, room)
             mutateCourse()
           }}
+          className={className}
         >
           Check Out
         </CheckOutButton>
@@ -105,6 +103,7 @@ export default function TACheckinButton({
           onClick={() => checkInTA()}
           disabled={disabled || !course}
           data-cy="check-in-button"
+          className={className}
         >
           Check In
         </CheckinButton>

--- a/packages/app/components/Today/TACheckinButton.tsx
+++ b/packages/app/components/Today/TACheckinButton.tsx
@@ -12,6 +12,12 @@ export const CheckinButton = styled(Button)`
   font-weight: 500;
   font-size: 14px;
   width: 100%;
+  margin-bottom: 12px;
+
+  @media (max-width: 650px) {
+    width: 30%;
+    margin-bottom: 0px;
+  }
 `
 
 export const CheckOutButton = styled(Button)`
@@ -20,6 +26,12 @@ export const CheckOutButton = styled(Button)`
   font-size: 14px;
   border-radius: 6px;
   width: 100%;
+  margin-bottom: 12px;
+
+  @media (max-width: 650px) {
+    width: 30%;
+    margin-bottom: 0px;
+  }
 `
 
 type CheckInButtonState =

--- a/packages/app/components/Today/TACheckinButton.tsx
+++ b/packages/app/components/Today/TACheckinButton.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { useCourse } from '../../hooks/useCourse'
+import { LoginOutlined, LogoutOutlined } from '@ant-design/icons'
 
 export const CheckinButton = styled(Button)`
   background: #1890ff;
@@ -12,6 +13,9 @@ export const CheckinButton = styled(Button)`
   font-weight: 500;
   font-size: 14px;
   margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   @media (max-width: 650px) {
     margin-bottom: 0px;
@@ -24,6 +28,9 @@ export const CheckOutButton = styled(Button)`
   font-size: 14px;
   border-radius: 6px;
   margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   @media (max-width: 650px) {
     margin-bottom: 0px;
@@ -92,6 +99,7 @@ export default function TACheckinButton({
             mutateCourse()
           }}
           className={className}
+          icon={<LogoutOutlined />}
         >
           Check Out
         </CheckOutButton>
@@ -104,6 +112,7 @@ export default function TACheckinButton({
           disabled={disabled || !course}
           data-cy="check-in-button"
           className={className}
+          icon={<LoginOutlined />}
         >
           Check In
         </CheckinButton>

--- a/packages/app/components/common/Footer.tsx
+++ b/packages/app/components/common/Footer.tsx
@@ -1,18 +1,10 @@
 import { ReactElement } from 'react'
-import styled from 'styled-components'
-
-const FullWidth = styled.footer`
-  width: 100%;
-  background: #ebebeb;
-
-  flex-shrink: 0;
-  padding: 12px 64px;
-`
 
 export function Footer(): ReactElement {
   return (
-    <FullWidth>
-      <div>Maintained by UBC Okanagan students with ❤️</div>
-    </FullWidth>
+    // Hide footer on mobile since screen space is more valuable
+    <footer className="hidden w-full flex-shrink-0 bg-[#ebebeb] px-6 py-3 md:block">
+      Maintained by UBC Okanagan students with ❤️
+    </footer>
   )
 }

--- a/packages/app/components/common/SelfAvatar.tsx
+++ b/packages/app/components/common/SelfAvatar.tsx
@@ -7,6 +7,7 @@ import AvatarWithInitals from './AvatarWithInitials'
 type SelfAvatarProps = {
   size: number
   style?: any
+  className?: string
 }
 
 type KOHAvatarProps = {
@@ -20,6 +21,7 @@ type KOHAvatarProps = {
 export default function SelfAvatar({
   size,
   style,
+  className,
 }: SelfAvatarProps): ReactElement {
   const profile = useProfile()
 
@@ -29,6 +31,7 @@ export default function SelfAvatar({
       photoURL={profile?.photoURL}
       name={profile?.name}
       style={style}
+      className={className}
     />
   )
 }

--- a/packages/app/styles/global.css
+++ b/packages/app/styles/global.css
@@ -126,3 +126,34 @@ body {
         visibility: hidden;
     }
 }
+
+.glowy:before, .glowy:after {
+	content: '';
+	position: absolute;
+	left: -1.5px;
+	top: -1.5px;
+	background: linear-gradient(45deg, #fb0094, #0000ff, #00ff00,#ffff00, #ff0000, #fb0094, 
+		#0000ff, #00ff00,#ffff00, #ff0000);
+	background-size: 400%;
+	width: calc(100% + 3px);
+	height: calc(100% + 3px);
+	z-index: -1;
+	animation: steam 20s linear infinite;
+    border-radius: 6px;
+}
+
+@keyframes steam {
+	0% {
+		background-position: 0 0;
+	}
+	50% {
+		background-position: 400% 0;
+	}
+	100% {
+		background-position: 0 0;
+	}
+}
+
+.glowy:after {
+	filter: blur(1.5px);
+}


### PR DESCRIPTION
# Description

Basically, a boat load of mostly smallish tweaks and improvements to the UI on the queue page (especially mobile) and on the today page. See screenshots below. Below each screenshot is some text to show what has changed. I wouldn't spend too much time bothering to review the code thoroughly for this one since it's unlikely anything is broken catastrophically (and would be easy for me to fix later anyway) and I don't think my code made the current frontend spaghetti much worse than it already was lol (like I actually made sure to add comments, meanwhile I don't think I saw a single one and some things were really hard to follow lol). 

This PR mostly just involves adjusting/adding styles to various elements, with some additional logic to add styles based on variables already in the class (i.e. there's no additional hook or server calls)

**main goal:** increase usability, decrease cognitive load for main use cases

Closes #88 

# Screenshots

## Student

### Desktop
![image](https://github.com/ubco-db/office-hours/assets/13655728/765a2a7c-70d2-421b-b1ef-0fc931d11247)
- adjusted margins around queue a bit
- added an icon to join queue
- Increased boldness of queue name header and decreased boldness of staff header
- italicized the "queue is up to date" widget 

![image](https://github.com/ubco-db/office-hours/assets/13655728/b0d3cd00-b421-42e0-ae16-04f61ef2e5f5)
- added highlight to your questions in the queue (to make it easily glancible where you are)

![image](https://github.com/ubco-db/office-hours/assets/13655728/040d8614-924c-4f4c-ba2d-e32900a5d87e)
- Shrunk avatar of current checked in staff to be less colossal
- Queues of current checked in staff now have the following (in order to help make it obvious for students to find what queue they probably want to go into):
	- ~~buttons become primary blue~~
	- animated rainbow border
- moved the queue tags (i.e. "professor queue" or "not accepting questions") to be closer to the queue title rather than close to the button (that way it's intuitively more of a description of the queue rather than a description of the button, plus it cleans up the area around the button to be less distracting)
- Removed some not-helpful text in an effort to reduce visual clutter: 
	- Queues with no notes provided no longer has "*no notes provided" text
	- Async question centre no longer has "staff checked in" text (I'm not really sure why it was there to begin with?)
- renamed "Async Question center" -> "Async Question Centre" (because Canada, eh)
- ~~Added little ">" arrows to the open queue buttons, might change it to a different icon later idk~~
- **Made the queue cards clickable**
	- **removed the 'Open Queue' buttons**
	- **has nice hover effects**
		- **drop shadow, card header lightens, arrow turns green (not sure about how to animate the arrow yet, too much animation is distracting but too little doesn't give additional help to convey that it's clickable)**
	- **gave mobile view a bit more dropdown shadow to make it appear more tappable** (should work well with the rainbow border)
- **Made async queue centre slightly purple to help differentiate it from the regular queues**
- **Moved async queue's "Ask your questions anytime!" text into the card content"
- **Made checked-in staff appear to the right of the 'Current Checked In Staff' text instead of below**

### Mobile
![image](https://github.com/ubco-db/office-hours/assets/13655728/646c2fda-5d7b-422b-adcf-e0c7f61c1ae2)
- Made use of empty page header:
	- Added course name as the main header
	- Current Queue name as the subheader (obviously not visible if you're not in a queue)
- Moved "Queue is up to date" text to underneath the "Queue" header, italicized it, and reduced its size
- Moved "Join Queue" button to be right beside the "Queue" header and made it less wide
- Adjusted margins all around so there's less gap between staff section and queue section
- Fixed alignment of the hamburger icon (top right nav button)
- hid footer on mobile
- moved the chatbot button to be not hugging the left side
- Reduced the padding in the staff queue cards so they take up just a little less space
- Reduced the padding of the student questions just a little

All of the changes above now result in the Queue starting in the top third of the screen rather the bottom third.

![image](https://github.com/ubco-db/office-hours/assets/13655728/e575b036-efc3-4c27-b5a7-32bf008c3b7c)
- Made adjustments to the "you are X in queue" banner
	- It now appears under the "Queue" header
	- Reduced the massive vertical margins around it 
	- Fixed the banner buttons going vertical
- Also, reduced the size and margins around the queue notes, which now also appear at the top (wasn't really sure where to put it exactly, though there's a good chance that the queue notes will be unset anyways. If you have any better ideas on where it could be put feel free to let me know)

![image](https://github.com/ubco-db/office-hours/assets/13655728/2a6b8f26-90b7-4390-b1e0-e7a93555e694)
- Centered "Queue" text
- changed navbar title from "Course" -> course logo + course name
![image](https://github.com/ubco-db/office-hours/assets/13655728/4cd34ad1-ebbf-4852-bbfd-2285bbc8e229)
- Made avatar a bit larger
- Aligned avatar with other nav elements
- Fixed the dropdown appearing on the right instead of under the avatar on the left

![image](https://github.com/ubco-db/office-hours/assets/13655728/b9baae93-900e-43ae-a461-84a5461c1c8e)
- Fixed the positioning of the dropdown to be on the right instead of left
- Tapping on a different queue will now properly close the whole nav drawer (before it wouldn't, meaning you would need to manually close the drawer after switching queues)

## TA/Professor

### Desktop
![image](https://github.com/ubco-db/office-hours/assets/13655728/61e26e13-bc33-44d1-b37a-25c810098ca2)
- All the stuff mentioned on the student side plus:
	- Edit notes button changed to an 'edit' icon button (reduce reading, easier cognitive load)
	- "*no notes provided*" text made a little more light gray
	- Icons added to checkin/checkout button (same on queue page)

![image](https://github.com/ubco-db/office-hours/assets/13655728/4b2a1b8a-5e7b-4f37-b74c-9cc9bf2fe3ee)
- Renamed "Add Students" button to "Add Students to Queue" to make it more obvious
- Added icons to the "Edit Queue Details" and "Add Students to Queue" buttons
- Removed the "Help Next" button since now it provides very little utility for how much visual noise it adds (it made sense with the old system where it require multiple clicks to help the next person but it's kinda redundant now)
- Check out button moved to top (probably more frequently used use-case)

![image](https://github.com/ubco-db/office-hours/assets/13655728/074b9733-821b-4c9e-9623-2bc0b5dda701)
- Adjusted and standardised margins between form items
- Adjusted and added margins between a lot items, including around the "Current Question Types" stuff and the zoom link stuff
- Made form item titles bold
- Made the current zoom link actually clickable
- Put colour picker, question type name, and add button all on the same line (question types don't get very long anyways)

![image](https://github.com/ubco-db/office-hours/assets/13655728/08acf3e6-c9da-4df8-b9ee-e7d63a3c91d9)
- Colour picker now appears below like so, rather than pushing the add button down

![image](https://github.com/ubco-db/office-hours/assets/13655728/2b4b35fd-6377-4fe4-a4c7-c3cfcc0a7aca)
- removed redundant "Search for students to be added" text

### Mobile

![image](https://github.com/ubco-db/office-hours/assets/13655728/464fc6f4-69fd-4711-922d-0223269bc10c)
In addition to what was listed on the student mobile changes:
- No longer a column of 6 buttons!
	- Check out, Edit Queue, and Add Students button are now all on the same row
	- As stated previously, Help Next was removed
	- Clear Queue and Delete Queue have been moved into the Edit Queue modal (but only for mobile), which not only gives more screen space but also makes it less easy to accidentally perform those actions on mobile
- "Edit Queue Details" gets shortened to "Edit Queue" on mobile
- "Add Students to Queue" gets shortened to "+ Students" on mobile
- The 3 buttons on students' question cards are now spread apart to make it harder to 'fat-thumb' the wrong button
- Other margin adjustments for extra screen space
- Changes to a lot of elements to use 'rem' or 'em' units rather 'px' to make it more dynamic for smaller phones

With the combined changes above, the "Queue" now starts above halfway at the screen rather than at the very bottom (or not visible at all, see below with an iPhone 12 Pro display, previous screenshots were with a Pixel 7)
![image](https://github.com/ubco-db/office-hours/assets/13655728/3b574f9f-183f-4551-bd4a-fdcba2cf17b4)


![image](https://github.com/ubco-db/office-hours/assets/13655728/b66dd0fb-b81a-45bb-bbac-0980e7d4ceda)
- (showcasing the moved "clear" and "delete queue" buttons)

+ probably some other small changes I forgot

#### ***  NEW  ***

![image](https://github.com/ubco-db/office-hours/assets/13655728/36587026-acd4-4e1d-9dfb-106578357720)
- Removed "Hotkeys" from dropdown
- Fixed its margins (antd gave it like 50% more margins on the left side)


- Edited the today page (specifically the queue cards) a lot, check out the new screenshots and changes (new stuff will be bolded) above. -> NOTE TO SELF: still need to do this


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Manual testing. Checking to see if the changes broke any related components. 

Since this is all UI changes, this won't break anything in the backend and if there are any issues that you guys find, it's easy for me to fix.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
