### PR TITLE
[GH Actions] Upgrade GHA pipeline packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: install node v14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 14
       - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
# Description
Upgrade actions packages to latest version as node 12 is going to be deprecated

## Type of change

- [x] CI/CD pipeline upgrade

# How Has This Been Tested?

- [x] Ran github actions test workflow with no issues

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
