### PR TITLE
fixed chatbot doc upload

### DIFF
--- a/packages/app/components/Settings/ChatbotSettings.tsx
+++ b/packages/app/components/Settings/ChatbotSettings.tsx
@@ -224,6 +224,12 @@ export default function ChatbotSettings(): ReactElement {
         ]}
       >
         <>
+          <div>
+            <p>
+              <strong>Accepted File Types:</strong> .docx, .pptx, .txt, .csv,
+              .pdf
+            </p>
+          </div>
           <div className="mb-2 flex h-fit w-full items-center justify-center gap-2">
             <div
               className={`${
@@ -259,12 +265,6 @@ export default function ChatbotSettings(): ReactElement {
                   },
                 ]}
               >
-                <div>
-                  <p>
-                    <strong>Accepted File Types:</strong> .docx, .pptx, .txt,
-                    .csv, .pdf
-                  </p>
-                </div>
                 <Input placeholder="Enter URL for a pdf file..." />
               </Form.Item>
             )}
@@ -279,12 +279,6 @@ export default function ChatbotSettings(): ReactElement {
                     },
                   ]}
                 >
-                  <div>
-                    <p>
-                      <strong>Accepted File Types:</strong> .docx, .pptx, .txt,
-                      .csv, .pdf
-                    </p>
-                  </div>
                   <Dragger {...props}>
                     <p className="ant-upload-drag-icon">
                       <InboxOutlined />


### PR DESCRIPTION
# Description
The doc was not able to be uploaded because of added 
"
          <div>
            <p>
              <strong>Accepted File Types:</strong> .docx, .pptx, .txt, .csv,
              .pdf
            </p>
          </div>"  before Input, yet to figure out why, but after moved that to the front, it works now. thanks for catching that Adam